### PR TITLE
Fixes #134

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -19,3 +19,4 @@
 ^codecov\.yml$
 ^sandbox$
 ^cran-comments\.md$
+^pkgdown$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pammtools
 Title: Piece-Wise Exponential Additive Mixed Modeling Tools for Survival Analysis
-Version: 0.1.17
-Date: 2019-12-12
+Version: 0.1.18
+Date: 2020-01-30
 Authors@R: c(
     person("Andreas", "Bender", , "andreas.bender@stat.uni-muenchen.de", role = c("aut", "cre"), comment=c(ORCID = "0000-0001-5628-8611")),
     person("Fabian", "Scheipl", , "fabian.scheipl@stat.uni-muenchen.de", role = c("aut")))
@@ -45,5 +45,5 @@ License: MIT + file LICENSE
 LazyData: true
 URL: https://github.com/adibender/pammtools
 BugReports: https://github.com/adibender/pammtools/issues
-RoxygenNote: 7.0.1
+RoxygenNote: 7.0.2
 Encoding: UTF-8


### PR DESCRIPTION
Apparently the factor levels (e.g. male/female) were switched in some situations after spliting and recombining using `map_dfr`. I changed the code so that now the data set is split according to grouping indices, CIs calculated and readded to the data directly (instead of col binding later on). Also appears to work for multiple factor variables: 

```r
library(dplyr)
library(mgcv)
library(pammtools)
library(ggplot2)
theme_set(theme_bw())
library(patchwork)

ped <- tumor %>% as_ped(Surv(days, status)~ age + sex + complications, id = "id")
pam <- gam(ped_status ~ s(tend, by = sex) + sex + complications, data = ped,
           family = poisson(), offset = offset)
ped_df <- ped %>% 
  make_newdata(
    tend = unique(tend), 
    complications = unique(complications), 
    sex = unique(sex)) %>%
  group_by(sex, complications)
(ped_df %>% add_cumu_hazard(pam) %>% 
ggplot(aes(x = tend, y = cumu_hazard, ymin = cumu_lower, ymax = cumu_upper, group = sex)) +
  geom_hazard(aes(col = sex)) + geom_ribbon(aes(fill = sex), alpha = 0.2) + ylim(c(0, 4)) +
  ylab(expression(hat(Lambda)(t))) + xlab(expression(t)) + facet_grid(complications~sex)) /
(ped_df %>% add_cumu_hazard(pam, ci_type = "sim", nsim = 500) %>%
  ggplot(aes(x = tend, y = cumu_hazard, ymin = cumu_lower, ymax = cumu_upper, group = sex)) +
  geom_hazard(aes(col = sex)) + geom_ribbon(aes(fill = sex), alpha = 0.2) + ylim(c(0, 4)) +
  ylab(expression(hat(Lambda)(t))) + xlab(expression(t)) + labs(title = "sim-based") + 
    facet_grid(complications~sex)) /
(ped_df %>% add_cumu_hazard(pam, ci_type = "delta") %>%
  ggplot(aes(x = tend, y = cumu_hazard, ymin = cumu_lower, ymax = cumu_upper, group = sex)) +
  geom_hazard(aes(col = sex)) + geom_ribbon(aes(fill = sex), alpha = 0.2) + ylim(c(0, 4)) +
  ylab(expression(hat(Lambda)(t))) + xlab(expression(t)) + labs(title = "delta-based") + 
  facet_grid(complications~sex))
```
