### PR TITLE
Consistently pass ... on to functions that call predict.gam

### DIFF
--- a/man/get_sim_ci.Rd
+++ b/man/get_sim_ci.Rd
@@ -4,7 +4,7 @@
 \alias{get_sim_ci}
 \title{Calculate simulation based confidence intervals}
 \usage{
-get_sim_ci(newdata, object, alpha = 0.05, nsim = 100L)
+get_sim_ci(newdata, object, alpha = 0.05, nsim = 100L, ...)
 }
 \description{
 Calculate simulation based confidence intervals


### PR DESCRIPTION
In `add-functions.R`, a number of the functions do not consistently pass `...` on down the chain of function calls, such that for different combinations of arguments, the incorrect Xp matrix is produced by `predict.gam()` if other arguments to `predict.gam()` have been passed in when calling the user-facing `add_foo` functions, for example if `terms` or `exclude` arguments to `predict.gam()` are used.

An example of this is in `get_surv_prob()`. If we have `ci = TRUE` and `ci_type = 'default'` (the defaults), then `...` are passed to `get_hazard` on [L436](https://github.com/adibender/pammtools/blob/master/R/add-functions.R#L436) but if `ci = FALSE` then `...` is *not* passed on to `get_hazard()` on [L458](https://github.com/adibender/pammtools/blob/master/R/add-functions.R#L458).

A similar problem affects the delta and sim CI methods; as these call `predict.gam()` again, they should also have `...` passed along to them otherwise they'll be generating different Xp matrices to those used to calculate the original hazard.

This PR

1. fixes the inconsistency in passing `...` to `get_hazard()` in `get_surv_prob` depending on whether `ci = TRUE` or `ci = FALSE`.
2. adds a `...` argument to `add_ci()` to facilitate passing arguments to `predict.gam()`, and
3. adds `...` arguments to the CI support functions and propagates `...` through to the `predict.gam()` calls

Being able to pass arguments to `predict.gam()` is useful as it allows, for example, to zero out random effect terms/smooths in a fitted GAM.