### PR TITLE
implement direction arg for stepribbon

### DIFF
--- a/R/ggplot-extensions.R
+++ b/R/ggplot-extensions.R
@@ -10,6 +10,7 @@
 #'   \code{\link[ggplot2]{geom_ribbon}} \code{geom_stepribbon}
 #'   inherits from \code{geom_ribbon}.
 #' @inheritParams ggplot2:::geom_ribbon
+#' @inheritParams ggplot2:::geom_step
 #' @examples
 #' library(ggplot2)
 #' huron <- data.frame(year = 1875:1972, level = as.vector(LakeHuron))
@@ -26,6 +27,7 @@ geom_stepribbon <- function(
   data        = NULL,
   stat        = "identity",
   position    = "identity",
+  direction   = "hv", 
   na.rm       = FALSE,
   show.legend = NA,
   inherit.aes = TRUE, ...) {
@@ -38,7 +40,7 @@ geom_stepribbon <- function(
     position    = position,
     show.legend = show.legend,
     inherit.aes = inherit.aes,
-    params      = list(na.rm = na.rm, ... )
+    params      = list(na.rm = na.rm, direction = direction, ... )
   )
 
 }
@@ -54,15 +56,59 @@ GeomStepribbon <- ggproto(
 
   extra_params = c("na.rm"),
 
-  draw_group = function(data, panel_scales, coord, na.rm = FALSE) {
+  draw_group = function(data, panel_scales, coord, na.rm = FALSE, direction = "hv") {
 
     if (na.rm) data <- data[complete.cases(data[c("x", "ymin", "ymax")]), ]
     data   <- rbind(data, data)
     data   <- data[order(data$x), ]
     data$x <- c(data$x[2:nrow(data)], NA)
-    data   <- data[complete.cases(data["x"]), ]
-    GeomRibbon$draw_group(data, panel_scales, coord, na.rm = FALSE)
-
+    data   <- ggplot2_stairstep(data[complete.cases(data["x"]), ], 
+                               direction = direction)
+    GeomRibbon$draw_group(data, panel_scales, coord, na.rm = na.rm)
   }
 
 )
+
+
+# code adapted from 
+# https://github.com/tidyverse/ggplot2/blob/9741da5050f81b7b5c012c56d02f45fc93d68f89/R/geom-path.r#L320
+ggplot2_stairstep <- function(data, direction = "hv") 
+{
+  direction <- match.arg(direction, c("hv", "vh", "mid"))
+  data <- as.data.frame(data)[order(data$x), ]
+  n <- nrow(data)
+  if (n <= 1) {
+    return(data[0, , drop = FALSE])
+  }
+  if (direction == "vh") {
+    xs <- rep(1:n, each = 2)[-2 * n]
+    ys <- c(1, rep(2:n, each = 2))
+  }
+  else if (direction == "hv") {
+    ys <- rep(1:n, each = 2)[-2 * n]
+    xs <- c(1, rep(2:n, each = 2))
+  }
+  else if (direction == "mid") {
+    xs <- rep(1:(n - 1), each = 2)
+    ys <- rep(1:n, each = 2)
+  }
+  else {
+    abort("Parameter `direction` is invalid.")
+  }
+  if (direction == "mid") {
+    gaps <- data$x[-1] - data$x[-n]
+    mid_x <- data$x[-n] + gaps/2
+    x <- c(data$x[1], mid_x[xs], data$x[n])
+    ymin <- c(data$ymin[ys])
+    ymax <- c(data$ymax[ys])
+    data_attr <- data[c(1, xs, n), 
+                      setdiff(names(data), c("x", "ymin", "ymax"))]
+  }
+  else {
+    x <- data$x[xs]
+    ymin <- data$ymin[ys]
+    ymax <- data$ymax[ys]
+    data_attr <- data[xs, setdiff(names(data), c("x", "ymin", "ymax"))]
+  }
+  cbind(data.frame(x = x, ymin = ymin, ymax = ymax), data_attr)
+}

--- a/man/geom_stepribbon.Rd
+++ b/man/geom_stepribbon.Rd
@@ -11,6 +11,7 @@ geom_stepribbon(
   data = NULL,
   stat = "identity",
   position = "identity",
+  direction = "hv",
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE,
@@ -43,6 +44,10 @@ layer, as a string.}
 
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
+
+\item{direction}{direction of stairs: 'vh' for vertical then horizontal,
+'hv' for horizontal then vertical, or 'mid' for step half-way between
+adjacent x-values.}
 
 \item{na.rm}{If \code{FALSE}, the default, missing values are removed with
 a warning. If \code{TRUE}, missing values are silently removed.}


### PR DESCRIPTION
``` r
library(ggplot2)
library(patchwork)
devtools::load_all("~/rpkgs/pammtools")
#> ℹ Loading pammtools

huron <- data.frame(year = 1875:1910, level = as.vector(LakeHuron)[1:36])
h <- ggplot(huron, aes(year))

h + geom_stepribbon(aes(ymin = level - 1, ymax = level + 1), fill = "grey70", direction = "vh") +
     geom_step(aes(y = level), direction = "vh") +
h + geom_stepribbon(aes(ymin = level - 1, ymax = level + 1), fill = "grey70", direction = "hv") +
  geom_step(aes(y = level), direction = "hv") +
h + geom_stepribbon(aes(ymin = level - 1, ymax = level + 1), fill = "grey70", direction = "mid") +
  geom_step(aes(y = level), direction = "mid") 
```

![](https://i.imgur.com/7oP3dov.png)

<sup>Created on 2021-04-07 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
