### PR TITLE
Fix ped tidyverse semantics and attribute sanitization

### DIFF
--- a/R/make-newdata.R
+++ b/R/make-newdata.R
@@ -54,10 +54,13 @@ sample_info.ped <- function(x) {
   grps <- group_vars(x)
   iv <- attr(x, "intvars")
   id_var <- attr(x, "id_var")
+  if (!is.null(id_var) && id_var %in% names(x)) {
+    x <- x %>%
+      group_by(!!sym(id_var)) %>%
+      slice(1) %>%
+      ungroup()
+  }
   x <- x %>%
-    group_by(!!sym(id_var)) %>%
-    slice(1) %>%
-    ungroup() %>%
     grouped_df(grps) %>%
     select(-one_of(iv))
   if (test_data_frame(x, min.rows = 1, min.cols = 1)) {

--- a/R/tidyverse-methods.R
+++ b/R/tidyverse-methods.R
@@ -10,6 +10,31 @@ re_attribute <- function(.data, attr2) {
   attr1 <- attributes(.data)
   attributes(.data) <- c(attr1,
     attr2[setdiff(names(attr1), names(attr2))])
+  .data <- sanitize_ped_attributes(.data)
+
+  .data
+
+}
+
+sanitize_ped_attributes <- function(.data) {
+
+  id_var <- attr(.data, "id_var")
+  if (!is.null(id_var) && !(id_var %in% names(.data))) {
+    attr(.data, "id_var") <- NULL
+  }
+
+  intvars <- attr(.data, "intvars")
+  if (!is.null(intvars)) {
+    attr(.data, "intvars") <- intersect(intvars, names(.data))
+  }
+
+  trafo_args <- attr(.data, "trafo_args")
+  if (!is.null(trafo_args) && !is.null(trafo_args[["id"]])) {
+    if (!(trafo_args[["id"]] %in% names(.data))) {
+      trafo_args[["id"]] <- NULL
+      attr(.data, "trafo_args") <- trafo_args
+    }
+  }
 
   .data
 
@@ -178,7 +203,7 @@ sample_frac.ped <- function(tbl, size = 1, replace = FALSE, weight = NULL, .env 
 
   classes_ped <- ped_classes(tbl)
   attr_ped    <- attributes(tbl)
-  tbl         <- sample_n(unped(tbl, classes_ped), size, replace, weight, .env, ...)
+  tbl         <- sample_frac(unped(tbl, classes_ped), size, replace, weight, .env, ...)
   tbl         <- reped(tbl, classes_ped)
 
   re_attribute(tbl, attr_ped)
@@ -340,7 +365,7 @@ right_join.ped <- function(x, y, by = NULL, copy = FALSE, suffix = c(".x", ".y")
   classes_ped_x <- ped_classes(x)
   classes_ped_y <- ped_classes(y)
   attr_ped_x    <- attributes(x)
-  .data         <- inner_join(unped(x, classes_ped_x), unped(y, classes_ped_y), by, copy, suffix, ...)
+  .data         <- right_join(unped(x, classes_ped_x), unped(y, classes_ped_y), by, copy, suffix, ...)
   .data         <- reped(.data, classes_ped_x)
 
   re_attribute(.data, attr_ped_x)

--- a/tests/testthat/test-tidyverse-S3methods.R
+++ b/tests/testthat/test-tidyverse-S3methods.R
@@ -23,6 +23,40 @@ test_that("ped class is preserved after dplyr operations", {
 
 })
 
+test_that("right_join.ped keeps unmatched right-hand rows", {
+
+  data("tumor")
+  ped <- as_ped(
+    data    = dplyr::slice(tumor, 2:3),
+    formula = Surv(days, status) ~ age,
+    cut     = c(0, 100, 400),
+    id      = "id")
+
+  lookup <- data.frame(id = c(1, 999), marker = c("known", "new"))
+  joined <- right_join(ped, lookup, by = "id")
+
+  expect_true(any(joined$id == 999))
+  expect_true(any(is.na(joined$ped_status[joined$id == 999])))
+
+})
+
+test_that("sample_frac.ped samples a fraction of rows", {
+
+  data("tumor")
+  ped <- as_ped(
+    data    = dplyr::slice(tumor, 2:3),
+    formula = Surv(days, status) ~ complications + age,
+    cut     = c(0, 100, 400),
+    id      = "id")
+
+  set.seed(123)
+  sampled <- sample_frac(ped, size = 0.5)
+
+  expect_gt(nrow(sampled), 0)
+  expect_lt(nrow(sampled), nrow(ped))
+
+})
+
 
 test_that("attributes are preserved", {
   # recurrent events data
@@ -55,5 +89,22 @@ test_that("attributes are preserved", {
     names(attributes(ungroup(group_by(gap_df, id)))),
     c("names", "row.names", "class", "breaks", "id_var", "intvars", "trafo_args",
     "time_var"))
+
+})
+
+test_that("ped attributes are sanitized after structural column drops", {
+
+  data("tumor")
+  ped <- as_ped(
+    data = dplyr::slice(tumor, 2:3),
+    formula = Surv(days, status) ~ age,
+    cut = c(0, 100, 400),
+    id = "id"
+  )
+  ped_no_id <- dplyr::select(ped, -id)
+
+  expect_null(attr(ped_no_id, "id_var"))
+  expect_false("id" %in% attr(ped_no_id, "intvars"))
+  expect_data_frame(sample_info(ped_no_id), nrows = 1L)
 
 })


### PR DESCRIPTION
### Summary
This PR fixes three ped/tidyverse correctness issues in one focused change set:

1) `right_join.ped()` called `inner_join()` internally.
2) `sample_frac.ped()` called `sample_n()` internally.
3) ped attributes could become stale after structural column drops.

### What changed
- Switched `right_join.ped()` to use `right_join()` semantics.
- Switched `sample_frac.ped()` to use `sample_frac()` semantics.
- Added ped-attribute sanitization in `re_attribute()` to drop/trim stale metadata.
- Made `sample_info.ped()` robust when `id_var` is absent.
- Added regressions in `test-tidyverse-S3methods.R`.

### Why
These are behavior bugs (not style): users can silently lose RHS rows, get incorrect sample sizes, or hit downstream failures due to invalid attributes.

### Validation
- `devtools::test(filter = "tidyverse-S3methods")`

Relates to #97