### PR TITLE
Fix CIF cause_var handling and lagged-survival integration

### DIFF
--- a/R/add-functions.R
+++ b/R/add-functions.R
@@ -728,18 +728,28 @@ add_cif.default <- function(
   coefs        <- coef(object)
   V            <- object$Vp
   sim_coef_mat <- mvtnorm::rmvnorm(nsim, mean = coefs, sigma = V)
+  assert_string(cause_var)
+  assert_choice(cause_var, colnames(newdata))
+  causes_model <- if (is.factor(newdata[[cause_var]])) {
+    levels(newdata[[cause_var]])
+  } else {
+    sort(unique(as.character(newdata[[cause_var]])))
+  }
 
   map_dfr(
     split(newdata, group_indices(newdata)),
     ~get_cif(
       newdata = .x, object = object, ci = ci, alpha = alpha, nsim = nsim,
       cause_var = cause_var, coefs = coefs, V = V, sim_coef_mat = sim_coef_mat,
-      time_var = time_var, ...)
+      causes_model = causes_model, time_var = time_var, ...)
   )
 
 }
 
 #' Calculate CIF for one cause
+#'
+#' @param causes_model Character vector of all cause labels represented in the
+#'   model. Used to construct cause-specific hazards for CIF integration.
 #'
 #' @keywords internal
 get_cif <- function(newdata, object, ...) {
@@ -761,6 +771,7 @@ get_cif.default <- function(
   coefs,
   V,
   sim_coef_mat,
+  causes_model,
   ...) {
 
   is_gam <- (inherits(object, "gam") | inherits(object, "scam"))
@@ -772,9 +783,7 @@ get_cif.default <- function(
   }
 
 
-  # causes_model <- as.factor(object$attr_ped$risks)
-  causes_model <- as.factor(levels(newdata[[cause_var]]))
-  cause_data   <- unique(newdata[[cause_var]])
+  cause_data <- unique(as.character(newdata[[cause_var]]))
 
   if(length(cause_data) > 1) {
     stop("Did you forget to group by cause?")
@@ -783,8 +792,13 @@ get_cif.default <- function(
   hazards <- map(
     causes_model,
     ~ {
-        .df <- mutate(newdata, cause = .x) %>%
-          arrange(.data[[time_var]], .by_group = TRUE)
+        .df <- newdata
+        if (is.factor(.df[[cause_var]])) {
+          .df[[cause_var]] <- factor(.x, levels = causes_model)
+        } else {
+          .df[[cause_var]] <- .x
+        }
+        .df <- arrange(.df, .data[[time_var]], .by_group = TRUE)
         X <- predict(object, .df, type = "lpmatrix")
         apply(sim_coef_mat, 1, function(z) exp(X %*% z))
       }
@@ -795,15 +809,17 @@ get_cif.default <- function(
     function(z) exp(-cumsum(z * newdata[["intlen"]])))
   names(hazards) <- causes_model
   # calculate cif
-  hazard           <- hazards[[cause_data]]
-  # Value of survival just prior to time-point
-  survival         <- overall_survivals - 1e-20
-  hps              <- hazard * survival
-  cifs             <- apply(hps, 2, function(z) cumsum(z * newdata[["intlen"]]))
-  newdata[["cif"]] <- rowMeans(cifs)
+  hazard <- hazards[[cause_data]]
+  survival <- rbind(
+    rep(1, ncol(overall_survivals)),
+    overall_survivals[-nrow(overall_survivals), , drop = FALSE]
+  )
+  hps <- hazard * survival
+  cifs <- apply(hps, 2, function(z) cumsum(z * newdata[["intlen"]]))
+  newdata[["cif"]] <- pmin(pmax(rowMeans(cifs), 0), 1)
  if(ci) {
-    newdata[["cif_lower"]] <- apply(cifs, 1, quantile, alpha/2)
-    newdata[["cif_upper"]] <- apply(cifs, 1, quantile, 1-alpha/2)
+    newdata[["cif_lower"]] <- pmin(pmax(apply(cifs, 1, quantile, alpha/2), 0), 1)
+    newdata[["cif_upper"]] <- pmin(pmax(apply(cifs, 1, quantile, 1 - alpha/2), 0), 1)
   }
 
   newdata
@@ -1097,5 +1113,3 @@ add_trans_ci <- function(newdata, object, nsim=100L, alpha=0.05, ...) {
 
   newdata
 }
-
-

--- a/man/get_cif.Rd
+++ b/man/get_cif.Rd
@@ -18,8 +18,13 @@ get_cif(newdata, object, ...)
   coefs,
   V,
   sim_coef_mat,
+  causes_model,
   ...
 )
+}
+\arguments{
+\item{causes_model}{Character vector of all cause labels represented in the
+model. Used to construct cause-specific hazards for CIF integration.}
 }
 \description{
 Calculate CIF for one cause

--- a/tests/testthat/test-add-functions.R
+++ b/tests/testthat/test-add-functions.R
@@ -304,8 +304,8 @@ test_that("CIF works with pamm", {
     add_cif(pam)
   expect_data_frame(ndf, nrows = 26L, ncols = 11L)
   expect_subset(c("cif", "cif_lower", "cif_upper"), colnames(ndf))
-  expect_true(all(ndf$cif < ndf$cif_upper))
-  expect_true(all(ndf$cif > ndf$cif_lower))
+  expect_true(all(ndf$cif <= ndf$cif_upper))
+  expect_true(all(ndf$cif >= ndf$cif_lower))
   expect_true(all(ndf$cif <= 1 & ndf$cif >= 0))
   expect_true(all(ndf$cif_lower <= 1 & ndf$cif_lower >= 0))
   expect_true(all(ndf$cif_upper <= 1 & ndf$cif_upper >= 0))
@@ -325,8 +325,8 @@ test_that("CIF works with mgcv::gam", {
     add_cif(pam)
   expect_data_frame(ndf, nrows = 26L, ncols = 11L)
   expect_subset(c("cif", "cif_lower", "cif_upper"), colnames(ndf))
-  expect_true(all(ndf$cif < ndf$cif_upper))
-  expect_true(all(ndf$cif > ndf$cif_lower))
+  expect_true(all(ndf$cif <= ndf$cif_upper))
+  expect_true(all(ndf$cif >= ndf$cif_lower))
   expect_true(all(ndf$cif <= 1 & ndf$cif >= 0))
   expect_true(all(ndf$cif_lower <= 1 & ndf$cif_lower >= 0))
   expect_true(all(ndf$cif_upper <= 1 & ndf$cif_upper >= 0))
@@ -347,12 +347,90 @@ test_that("CIF works with character causes", {
     add_cif(pam)
   expect_data_frame(ndf, nrows = 26L, ncols = 11L)
   expect_subset(c("cif", "cif_lower", "cif_upper"), colnames(ndf))
-  expect_true(all(ndf$cif < ndf$cif_upper))
-  expect_true(all(ndf$cif > ndf$cif_lower))
+  expect_true(all(ndf$cif <= ndf$cif_upper))
+  expect_true(all(ndf$cif >= ndf$cif_lower))
   expect_true(all(ndf$cif <= 1 & ndf$cif >= 0))
   expect_true(all(ndf$cif_lower <= 1 & ndf$cif_lower >= 0))
   expect_true(all(ndf$cif_upper <= 1 & ndf$cif_upper >= 0))
   
+})
+
+test_that("CIF works with non-default cause_var names", {
+
+  set.seed(211758)
+  df <- data.frame(time = rexp(20), status = sample(c(0, 1, 2), 20, replace = TRUE))
+  ped_cr <- as_ped(df, Surv(time, status) ~ ., id = "id") %>%
+    mutate(event_type = factor(cause, labels = c("Death", "Discharge"))) %>%
+    select(-cause)
+  pam <- pamm(ped_status ~ s(tend, by = event_type), data = ped_cr)
+  ndf <- ped_cr %>%
+    make_newdata(tend = unique(tend), event_type = unique(event_type)) %>%
+    group_by(event_type) %>%
+    add_cif(pam, cause_var = "event_type")
+
+  expect_data_frame(ndf, nrows = 26L, ncols = 11L)
+  expect_subset(c("cif", "cif_lower", "cif_upper"), colnames(ndf))
+  expect_true(all(ndf$cif <= 1 & ndf$cif >= 0))
+  expect_true(all(ndf$cif_lower <= 1 & ndf$cif_lower >= 0))
+  expect_true(all(ndf$cif_upper <= 1 & ndf$cif_upper >= 0))
+
+})
+
+test_that("CIF uses survival at the start of each interval", {
+
+  set.seed(211758)
+  df <- data.frame(time = rexp(20), status = sample(c(0, 1, 2), 20, replace = TRUE))
+  ped_cr <- as_ped(df, Surv(time, status) ~ ., id = "id") %>%
+    mutate(cause = as.factor(cause))
+  pam <- pamm(ped_status ~ s(tend, by = cause), data = ped_cr)
+  ndf <- ped_cr %>%
+    make_newdata(tend = unique(tend), cause = unique(cause)) %>%
+    group_by(cause)
+
+  nsim <- 40L
+  target_cause <- levels(ndf$cause)[1]
+  ndf_target <- ndf %>%
+    filter(cause == target_cause) %>%
+    arrange(tend)
+  coefs <- coef(pam)
+  V <- pam$Vp
+  causes_model <- levels(ndf$cause)
+
+  set.seed(42)
+  sim_coef_mat <- mvtnorm::rmvnorm(nsim, mean = coefs, sigma = V)
+  hazards <- map(
+    causes_model,
+    ~ {
+      .df <- mutate(ndf_target, cause = factor(.x, levels = causes_model))
+      X <- predict(pam, .df, type = "lpmatrix")
+      apply(sim_coef_mat, 1, function(z) exp(X %*% z))
+    }
+  )
+  names(hazards) <- causes_model
+  overall_survivals <- apply(
+    Reduce("+", hazards),
+    2,
+    function(z) exp(-cumsum(z * ndf_target$intlen))
+  )
+  lagged_survival <- rbind(
+    rep(1, ncol(overall_survivals)),
+    overall_survivals[-nrow(overall_survivals), , drop = FALSE]
+  )
+  expected_cif <- apply(
+    hazards[[target_cause]] * lagged_survival,
+    2,
+    function(z) cumsum(z * ndf_target$intlen)
+  ) %>%
+    rowMeans()
+
+  set.seed(42)
+  observed <- ndf %>%
+    add_cif(pam, ci = FALSE, nsim = nsim) %>%
+    filter(cause == target_cause) %>%
+    arrange(tend)
+
+  expect_equal(observed$cif, expected_cif, tolerance = 1e-8)
+
 })
 
 test_that("Transition Probability works", {


### PR DESCRIPTION
### Summary
This PR improves CIF correctness and API robustness:

1) `add_cif()` now respects configurable `cause_var` names consistently.
2) CIF accumulation now uses survival from the start of each interval (lagged survival).

### What changed
- Validated and threaded `cause_var` through hazard construction.
- Computed cause levels once at the grouped-call entry point.
- Updated CIF accumulation to multiply hazard by lagged survival.
- Added/updated CIF regressions in `test-add-functions.R`.
- Added roxygen documentation for `get_cif.default` argument `causes_model` and regenerated Rd to keep codoc clean.

### Why
The first fix removes schema assumptions (`cause` hardcoding). The second corrects interval-wise CIF accumulation.

### Validation
- `devtools::test(filter = "add-functions")`
- `R CMD build` + `R CMD check`: Status OK

Relates to #216