### PR TITLE
coverage test only on PR branches, not master

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,8 +1,6 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  push:
-    branches: [main, master]
   pull_request:
 
 name: test-coverage.yaml


### PR DESCRIPTION
Drops the master push trigger from test-coverage.yaml. Codecov upload fails on every master merge because no CODECOV_TOKEN is configured. Coverage is still computed and printed on PR runs.