### PR TITLE
[codex] Add prediction-grid boundary rows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,11 @@
   (previously used dplyr internally).
 * `gg_state_occupation()` is now exported. Dead parameters `group_labels` and
   `nrow` have been removed; user-supplied `ncol` is now respected.
+* `add_surv_prob()`, `add_cif()`, and `add_trans_prob()` now include plotting
+  boundary rows at `tend = 0` (or the selected `time_var`). Boundary values are
+  set to their known limits, `S(0) = 1`, `CIF(0) = 0`, and off-diagonal
+  transition probabilities `P_rs(0) = 0`, with collapsed confidence interval
+  bounds when requested. `add_cumu_hazard()` keeps the original prediction grid.
 
 # pammtools 0.7.5
 

--- a/R/add-functions.R
+++ b/R/add-functions.R
@@ -731,10 +731,10 @@ set_cumulative_boundary_values <- function(
   values,
   interval_length = NULL
 ) {
-  newdata[[time_var]] <- 0
+  newdata[[time_var]][] <- 0
 
   if (!is.null(interval_length) && interval_length %in% colnames(newdata)) {
-    newdata[[interval_length]] <- 0
+    newdata[[interval_length]][] <- 0
   }
   if ("tstart" %in% colnames(newdata)) {
     newdata[["tstart"]] <- 0

--- a/R/add-functions.R
+++ b/R/add-functions.R
@@ -197,17 +197,17 @@ resolve_time_var <- function(time_var, object, newdata) {
 #' \code{c("hazard", "se", "lower", "upper")} will be overwritten.
 #' @param time_var Name of the variable used for the baseline hazard. Defaults
 #'   to \code{"tend"}.
-#'   
+#'
 #' @details
 #' When computing cumulative hazards or survival probabilities across groups,
 #' the input data must be grouped via \code{group_by()} prior to calling
 #' \code{add_cumu_hazard()} or \code{add_surv_prob()}. Omitting
 #' \code{group_by()} will not produce an error or warning but will return
 #' silently incorrect results, as the cumulative hazard will be accumulated
-#' over the entire dataset rather than within each group. 
+#' over the entire dataset rather than within each group.
 #' See the \href{https://adibender.github.io/pammtools/articles/convenience.html#cumulative-hazard}{workflow vignette}
 #' for a worked example.
-#' 
+#'
 #' @import checkmate dplyr mgcv
 #' @importFrom stats predict
 #' @examples
@@ -350,8 +350,15 @@ add_cumu_hazard <- function(
   time_var <- resolve_time_var(time_var, object, newdata)
 
   joindata <- reconstruct_cutpoints(newdata, object, time_var, interval_length)
-  joindata <- get_cumu_hazard(joindata, object, ci = ci, se_mult = se_mult,
-                              time_var = time_var, interval_length = interval_length, ...)
+  joindata <- get_cumu_hazard(
+    joindata,
+    object,
+    ci = ci,
+    se_mult = se_mult,
+    time_var = time_var,
+    interval_length = interval_length,
+    ...
+  )
 
   suppressMessages(
     newdata %>% left_join(joindata)
@@ -481,6 +488,22 @@ get_cumu_hazard <- function(
 #' for the specified covariate and follow-up information (and CIs
 #' \code{surv_lower}, \code{surv_upper} if \code{ci=TRUE}).
 #'
+#' @details
+#' When computing cumulative hazards or survival probabilities across groups,
+#' the input data must be grouped via \code{group_by()} prior to calling
+#' \code{add_cumu_hazard()} or \code{add_surv_prob()}. Omitting
+#' \code{group_by()} will not produce an error or warning but will return
+#' silently incorrect results, as the cumulative hazard will be accumulated
+#' over the entire dataset rather than within each group.
+#' See the \href{https://adibender.github.io/pammtools/articles/convenience.html#cumulative-hazard}{workflow vignette}
+#' for a worked example.
+#'
+#' The returned data contains one boundary row per group at \code{time_var = 0}
+#' for plotting cumulative quantities from the time origin. On this row,
+#' \code{surv_prob = 1}; if confidence intervals are requested,
+#' \code{surv_lower = surv_upper = 1}. If an interval-length column is present,
+#' it is set to \code{0} on the boundary row.
+#'
 #' @inherit add_cumu_hazard
 #' @examples
 #' ped <- tumor[1:50,] %>% as_ped(Surv(days, status)~ age)
@@ -515,6 +538,8 @@ add_surv_prob <- function(
     newdata <- newdata %>% select(-one_of(rm.vars))
   }
 
+  newdata <- drop_cumulative_boundary(newdata, time_var)
+
   if (!interval_length %in% colnames(newdata)) {
     newdata <- reconstruct_intlen(
       newdata,
@@ -523,7 +548,7 @@ add_surv_prob <- function(
     )
   }
 
-  get_surv_prob(
+  out <- get_surv_prob(
     newdata,
     object,
     ci = ci,
@@ -531,6 +556,14 @@ add_surv_prob <- function(
     time_var = time_var,
     interval_length = interval_length,
     ...
+  )
+  out <- restore_prediction_attrs(out, newdata)
+
+  add_cumulative_boundary(
+    out,
+    time_var = time_var,
+    values = c(surv_prob = 1, surv_lower = 1, surv_upper = 1),
+    interval_length = interval_length
   )
 }
 
@@ -647,6 +680,91 @@ get_surv_prob <- function(
   vars_exclude <- setdiff(vars_exclude, haz_vars_in_data)
   if (length(vars_exclude) != 0) {
     newdata <- newdata %>% select(-one_of(vars_exclude))
+  }
+
+  newdata
+}
+
+drop_cumulative_boundary <- function(newdata, time_var) {
+  boundary_rows <- !is.na(newdata[[time_var]]) & newdata[[time_var]] == 0
+  if (!any(boundary_rows)) {
+    return(newdata)
+  }
+
+  out <- newdata %>%
+    filter(is.na(.data[[time_var]]) | .data[[time_var]] != 0)
+
+  restore_prediction_attrs(out, newdata)
+}
+
+add_cumulative_boundary <- function(
+  newdata,
+  time_var,
+  values,
+  interval_length = NULL
+) {
+  if (!nrow(newdata)) {
+    return(newdata)
+  }
+
+  old_groups <- group_vars(newdata)
+  out <- newdata %>%
+    slice(1, .preserve = TRUE) %>%
+    set_cumulative_boundary_values(
+      time_var = time_var,
+      values = values,
+      interval_length = interval_length
+    ) %>%
+    bind_rows(newdata)
+
+  if (length(old_groups)) {
+    out <- out %>% group_by(across(all_of(old_groups)))
+  }
+  out <- out %>% arrange(.data[[time_var]], .by_group = TRUE)
+
+  restore_prediction_attrs(out, newdata)
+}
+
+set_cumulative_boundary_values <- function(
+  newdata,
+  time_var,
+  values,
+  interval_length = NULL
+) {
+  newdata[[time_var]] <- 0
+
+  if (!is.null(interval_length) && interval_length %in% colnames(newdata)) {
+    newdata[[interval_length]] <- 0
+  }
+  if ("tstart" %in% colnames(newdata)) {
+    newdata[["tstart"]] <- 0
+  }
+  if ("intmid" %in% colnames(newdata)) {
+    newdata[["intmid"]] <- 0
+  }
+  if ("interval" %in% colnames(newdata)) {
+    is.na(newdata[["interval"]]) <- TRUE
+  }
+  if ("offset" %in% colnames(newdata)) {
+    newdata[["offset"]][] <- NA_real_
+  }
+
+  value_names <- intersect(names(values), colnames(newdata))
+  for (value_name in value_names) {
+    newdata[[value_name]] <- values[[value_name]]
+  }
+
+  newdata
+}
+
+restore_prediction_attrs <- function(newdata, template) {
+  structural_attrs <- c("names", "row.names", "class", "groups")
+  custom_attrs <- setdiff(names(attributes(template)), structural_attrs)
+  for (attr_name in custom_attrs) {
+    attr(newdata, attr_name) <- attr(template, attr_name)
+  }
+  if (inherits(template, "ped") && !inherits(newdata, "ped")) {
+    class(newdata) <- c("ped", class(newdata))
   }
 
   newdata
@@ -847,14 +965,21 @@ get_sim_ci_surv <- function(
 #' @param cause_var Character. Column name of the 'cause' variable.
 #' @param interval_length \code{Character}, defaults to \code{"intlen"}.
 #'   contains the interval length in `newdata`.
-#'   
+#'
 #' @details
 #' When computing cumulative incidence for multiple groups, the input data must
 #' be grouped via \code{group_by()} before calling this function. Omitting
 #' \code{group_by()} will not produce an error or warning but will return
 #' silently incorrect results, as the cumulative incidence will be accumulated
 #' over the entire dataset rather than within each group.
-#' 
+#'
+#' The returned data contains one boundary row per group at \code{time_var = 0}
+#' for plotting cumulative incidence from the time origin. On this row,
+#' \code{cif = 0}; if confidence intervals are requested,
+#' \code{cif_lower = cif_upper = 0}. If an interval-length column is present,
+#' it is set to \code{0} on the boundary row. \code{add_cumu_hazard()} keeps the
+#' original prediction grid and does not add this plotting boundary row.
+#'
 #' @examples
 #' \donttest{
 #' if (require("etm")) {
@@ -872,7 +997,7 @@ get_sim_ci_surv <- function(
 #'     add_cif(pam)
 #' }
 #' }
-#'    
+#'
 #' @export
 add_cif <- function(
   newdata,
@@ -897,9 +1022,25 @@ add_cif.default <- function(
   interval_length = "intlen",
   ...
 ) {
-
   interval_length <- quo_name(enquo(interval_length))
   time_var <- resolve_time_var(time_var, object, newdata)
+
+  if (!overwrite) {
+    if ("cif" %in% names(newdata)) {
+      stop(
+        "Data set already contains 'cif' column.
+        Set `overwrite=TRUE` to overwrite"
+      )
+    }
+  } else {
+    rm.vars <- intersect(
+      c("cif", "cif_lower", "cif_upper"),
+      names(newdata)
+    )
+    newdata <- newdata %>% select(-one_of(rm.vars))
+  }
+
+  newdata <- drop_cumulative_boundary(newdata, time_var)
 
   joindata <- reconstruct_cutpoints(newdata, object, time_var, interval_length)
 
@@ -928,9 +1069,17 @@ add_cif.default <- function(
       ...
     )
   )
-  
-  suppressMessages(
+
+  out <- suppressMessages(
     newdata %>% left_join(joindata)
+  )
+  out <- restore_prediction_attrs(out, newdata)
+
+  add_cumulative_boundary(
+    out,
+    time_var = time_var,
+    values = c(cif = 0, cif_lower = 0, cif_upper = 0),
+    interval_length = interval_length
   )
 }
 
@@ -967,7 +1116,6 @@ get_cif.default <- function(
   sim_coef_mat,
   ...
 ) {
-
   time_var <- resolve_time_var(time_var, object, newdata)
   assert_string(interval_length)
   assert_choice(interval_length, colnames(newdata))
@@ -1010,14 +1158,20 @@ get_cif.default <- function(
   cif_increments <- (hazard / total_hazard) *
     survival *
     (1 - exp(-total_hazard * dt))
-  
+
   # cumulative CIF
   cifs <- apply(cif_increments, 2, cumsum)
-  
+
   newdata[["cif"]] <- pmin(pmax(rowMeans(cifs), 0), 1)
   if (ci) {
-    newdata[["cif_lower"]] <- pmin(pmax(apply(cifs, 1, quantile, alpha / 2, na.rm = TRUE), 0), 1)
-    newdata[["cif_upper"]] <- pmin(pmax(apply(cifs, 1, quantile, 1 - alpha / 2, na.rm = TRUE), 0), 1)
+    newdata[["cif_lower"]] <- pmin(
+      pmax(apply(cifs, 1, quantile, alpha / 2, na.rm = TRUE), 0),
+      1
+    )
+    newdata[["cif_upper"]] <- pmin(
+      pmax(apply(cifs, 1, quantile, 1 - alpha / 2, na.rm = TRUE), 0),
+      1
+    )
   }
 
   newdata
@@ -1026,16 +1180,15 @@ get_cif.default <- function(
 ## Transition Probability Matrix for multi-state data
 #' @keywords internal
 get_trans_prob <- function(
-    newdata,
-    time_var        = "tend",
-    interval_length = "intlen",
-    transition      = "transition",
-    tend            = "tend",
-    cumu_hazard     = "cumu_hazard",
-    sep             = "->",
-    ...
+  newdata,
+  time_var = "tend",
+  interval_length = "intlen",
+  transition = "transition",
+  tend = "tend",
+  cumu_hazard = "cumu_hazard",
+  sep = "->",
+  ...
 ) {
-
   if (is.null(time_var)) {
     time_var <- tend
   }
@@ -1051,12 +1204,15 @@ get_trans_prob <- function(
   assert_data_frame(newdata, all.missing = FALSE)
 
   transition_var <- transition
-  unique_transition <- transition_state_table(newdata[[transition_var]], sep = sep)
+  unique_transition <- transition_state_table(
+    newdata[[transition_var]],
+    sep = sep
+  )
   names(unique_transition)[1] <- transition_var
   unique_tend <- sort(unique(newdata[[time_var]]))
 
   n_trans <- nrow(unique_transition)
-  n_t     <- length(unique_tend)
+  n_t <- length(unique_tend)
 
   m <- max(unique_transition$to_int)
   M <- array(0, dim = c(m, m, n_trans))
@@ -1067,12 +1223,17 @@ get_trans_prob <- function(
     seq_len(n_trans)
   )
   M[idx] <- 1
-  M[cbind(unique_transition$from_int,
-          unique_transition$from_int,
-          seq_len(n_trans))] <- -1
+  M[cbind(
+    unique_transition$from_int,
+    unique_transition$from_int,
+    seq_len(n_trans)
+  )] <- -1
 
   newdata$delta_cumu_hazard <- 0
-  split_idx <- split(seq_len(nrow(newdata)), as.character(newdata[[transition_var]]))
+  split_idx <- split(
+    seq_len(nrow(newdata)),
+    as.character(newdata[[transition_var]])
+  )
   for (idx_group in split_idx) {
     idx_group <- idx_group[order(newdata[[time_var]][idx_group])]
     ch <- newdata[[cumu_hazard]][idx_group]
@@ -1106,7 +1267,7 @@ get_trans_prob <- function(
 
   cum_A <- array(NA_real_, dim = c(m, m, n_t))
   for (t in seq_len(n_t)) {
-    cum_A[,,t] <- matrix(cum_A_list[[t]], m, m)
+    cum_A[,, t] <- matrix(cum_A_list[[t]], m, m)
   }
 
   prob_mat <- matrix(0, nrow = n_t, ncol = n_trans)
@@ -1114,7 +1275,7 @@ get_trans_prob <- function(
     prob_mat[, k] <- cum_A[
       unique_transition$from_int[k],
       unique_transition$to_int[k],
-      ]
+    ]
   }
   colnames(prob_mat) <- as.character(unique_transition[[transition_var]])
 
@@ -1164,16 +1325,21 @@ transition_state_table <- function(transitions, sep = "->") {
     stop(
       "Could not split transition label(s) ",
       paste(shQuote(labs[bad]), collapse = ", "),
-      " on separator '", sep, "'. ",
-      "Each transition must look like 'from", sep, "to'."
+      " on separator '",
+      sep,
+      "'. ",
+      "Each transition must look like 'from",
+      sep,
+      "to'."
     )
   }
   from_str <- vapply(parts, `[[`, character(1), 2L)
-  to_str   <- vapply(parts, `[[`, character(1), 3L)
+  to_str <- vapply(parts, `[[`, character(1), 3L)
 
   from_int_try <- suppressWarnings(as.integer(from_str))
-  to_int_try   <- suppressWarnings(as.integer(to_str))
-  numeric_mode <- !anyNA(from_int_try) && !anyNA(to_int_try) &&
+  to_int_try <- suppressWarnings(as.integer(to_str))
+  numeric_mode <- !anyNA(from_int_try) &&
+    !anyNA(to_int_try) &&
     all(from_str == as.character(from_int_try)) &&
     all(to_str == as.character(to_int_try))
 
@@ -1181,20 +1347,22 @@ transition_state_table <- function(transitions, sep = "->") {
     state_min <- min(c(from_int_try, to_int_try))
     shift <- if (state_min == 0L) 1L else 0L
     from_int <- from_int_try + shift
-    to_int   <- to_int_try + shift
+    to_int <- to_int_try + shift
     if (min(c(from_int, to_int)) < 1L) {
-      stop("Negative state indices are not supported in numeric transition labels.")
+      stop(
+        "Negative state indices are not supported in numeric transition labels."
+      )
     }
   } else {
     states <- sort(unique(c(from_str, to_str)))
     from_int <- match(from_str, states)
-    to_int   <- match(to_str, states)
+    to_int <- match(to_str, states)
   }
 
   data.frame(
     transition = labs,
-    from_int   = from_int,
-    to_int     = to_int,
+    from_int = from_int,
+    to_int = to_int,
     stringsAsFactors = FALSE
   )
 }
@@ -1228,14 +1396,20 @@ transition_state_table <- function(transitions, sep = "->") {
 #' @param transition \code{Character}, defaults to \code{"transition"}.
 #'   contains the transition labels in `newdata`.
 #' @param ... Further arguments passed to underlying methods.
-#' 
+#'
 #' @details
 #' When computing transition probabilities for multiple groups, the input data must
 #' be grouped via \code{group_by()} before calling this function. Omitting
 #' \code{group_by()} will not produce an error or warning but will return
 #' silently incorrect results, as the transition probability will be accumulated
 #' over the entire dataset rather than within each group.
-#' 
+#'
+#' The returned data contains one boundary row per group and transition at
+#' \code{time_var = 0} for plotting transition probabilities from the time
+#' origin. On this row, \code{trans_prob = 0}; if confidence intervals are
+#' requested, \code{trans_lower = trans_upper = 0}. If an interval-length
+#' column is present, it is set to \code{0} on the boundary row.
+#'
 #' @examplesIf require("mstate")
 #'   data("prothr", package = "mstate")
 #'   prothr <- prothr |>
@@ -1293,6 +1467,7 @@ add_trans_prob <- function(
     )
     newdata <- newdata %>% select(-one_of(rm.vars))
   }
+  newdata <- drop_cumulative_boundary(newdata, time_var)
 
   assert_subset(transition_var, names(newdata))
   assert_subset(time_var, names(newdata))
@@ -1310,7 +1485,11 @@ add_trans_prob <- function(
 
   split_groups <- setdiff(old_groups, transition_var)
   ordering_vars <- c(split_groups, transition_var, time_var)
-  newdata <- newdata[do.call(order, newdata[, ordering_vars, drop = FALSE]), , drop = FALSE]
+  newdata <- newdata[
+    do.call(order, newdata[, ordering_vars, drop = FALSE]),
+    ,
+    drop = FALSE
+  ]
 
   if (!has_cumu) {
     newdata <- do.call(
@@ -1335,11 +1514,26 @@ add_trans_prob <- function(
         transition = transition_var
       )
   }
+  newdata <- add_cumulative_boundary(
+    newdata,
+    time_var = time_var,
+    values = c(
+      cumu_hazard = 0,
+      trans_prob = 0,
+      trans_lower = 0,
+      trans_upper = 0
+    ),
+    interval_length = interval_length
+  )
 
   if (length(split_groups) == 0L) {
     grp_index <- list(seq_len(nrow(newdata)))
   } else {
-    grp <- interaction(newdata[, split_groups, drop = FALSE], drop = TRUE, lex.order = TRUE)
+    grp <- interaction(
+      newdata[, split_groups, drop = FALSE],
+      drop = TRUE,
+      lex.order = TRUE
+    )
     grp_index <- split(seq_len(nrow(newdata)), grp)
   }
 
@@ -1397,7 +1591,7 @@ get_sim_cumu <- function(newdata, interval_length = "intlen", ...) {
 
 #' Add transition probabilities confidence intervals
 #' @keywords internal
-add_trans_ci <- function(newdata, object, nsim=100L, alpha=0.05, ...) {
+add_trans_ci <- function(newdata, object, nsim = 100L, alpha = 0.05, ...) {
   dots <- list(...)
   time_var <- dots[["time_var"]]
   interval_length <- dots[["interval_length"]]
@@ -1428,11 +1622,19 @@ add_trans_ci <- function(newdata, object, nsim=100L, alpha=0.05, ...) {
   coefs <- coef(object)
   V <- object$Vp
 
-  groups_array <- interaction(df[, group_vars_ordered, drop = FALSE], drop = TRUE, lex.order = TRUE)
+  groups_array <- interaction(
+    df[, group_vars_ordered, drop = FALSE],
+    drop = TRUE,
+    lex.order = TRUE
+  )
   array_idx_list <- split(seq_len(nrow(df)), groups_array)
 
   if (length(group_vars_trans) > 0) {
-    groups_trans <- interaction(df[, group_vars_trans, drop = FALSE], drop = TRUE, lex.order = TRUE)
+    groups_trans <- interaction(
+      df[, group_vars_trans, drop = FALSE],
+      drop = TRUE,
+      lex.order = TRUE
+    )
     trans_idx_list <- split(seq_len(nrow(df)), groups_trans)
   } else {
     trans_idx_list <- list(seq_len(nrow(df)))
@@ -1474,8 +1676,20 @@ add_trans_ci <- function(newdata, object, nsim=100L, alpha=0.05, ...) {
     sim_trans_probs[, i] <- trans_prob
   }
 
-  df$trans_lower <- apply(sim_trans_probs, 1, quantile, probs = alpha / 2, na.rm = TRUE)
-  df$trans_upper <- apply(sim_trans_probs, 1, quantile, probs = 1 - alpha / 2, na.rm = TRUE)
+  df$trans_lower <- apply(
+    sim_trans_probs,
+    1,
+    quantile,
+    probs = alpha / 2,
+    na.rm = TRUE
+  )
+  df$trans_upper <- apply(
+    sim_trans_probs,
+    1,
+    quantile,
+    probs = 1 - alpha / 2,
+    na.rm = TRUE
+  )
 
   df <- df[order(df$.orig_row), , drop = FALSE]
   df$.orig_row <- NULL

--- a/man/add_cif.Rd
+++ b/man/add_cif.Rd
@@ -63,6 +63,13 @@ be grouped via \code{group_by()} before calling this function. Omitting
 \code{group_by()} will not produce an error or warning but will return
 silently incorrect results, as the cumulative incidence will be accumulated
 over the entire dataset rather than within each group.
+
+The returned data contains one boundary row per group at \code{time_var = 0}
+for plotting cumulative incidence from the time origin. On this row,
+\code{cif = 0}; if confidence intervals are requested,
+\code{cif_lower = cif_upper = 0}. If an interval-length column is present,
+it is set to \code{0} on the boundary row. \code{add_cumu_hazard()} keeps the
+original prediction grid and does not add this plotting boundary row.
 }
 \examples{
 \donttest{
@@ -81,5 +88,5 @@ if (require("etm")) {
     add_cif(pam)
 }
 }
-   
+
 }

--- a/man/add_surv_prob.Rd
+++ b/man/add_surv_prob.Rd
@@ -59,6 +59,12 @@ silently incorrect results, as the cumulative hazard will be accumulated
 over the entire dataset rather than within each group.
 See the \href{https://adibender.github.io/pammtools/articles/convenience.html#cumulative-hazard}{workflow vignette}
 for a worked example.
+
+The returned data contains one boundary row per group at \code{time_var = 0}
+for plotting cumulative quantities from the time origin. On this row,
+\code{surv_prob = 1}; if confidence intervals are requested,
+\code{surv_lower = surv_upper = 1}. If an interval-length column is present,
+it is set to \code{0} on the boundary row.
 }
 \examples{
 ped <- tumor[1:50,] \%>\% as_ped(Surv(days, status)~ age)

--- a/man/add_trans_prob.Rd
+++ b/man/add_trans_prob.Rd
@@ -62,6 +62,12 @@ be grouped via \code{group_by()} before calling this function. Omitting
 \code{group_by()} will not produce an error or warning but will return
 silently incorrect results, as the transition probability will be accumulated
 over the entire dataset rather than within each group.
+
+The returned data contains one boundary row per group and transition at
+\code{time_var = 0} for plotting transition probabilities from the time
+origin. On this row, \code{trans_prob = 0}; if confidence intervals are
+requested, \code{trans_lower = trans_upper = 0}. If an interval-length
+column is present, it is set to \code{0} on the boundary row.
 }
 \examples{
 \dontshow{if (require("mstate")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}

--- a/tests/testthat/test-add-functions.R
+++ b/tests/testthat/test-add-functions.R
@@ -876,7 +876,7 @@ test_that("Transition Probability works", {
   ndf_in <- ped_msm %>%
     make_newdata(tend = unique(tend), transition = unique(transition)) %>%
     group_by(transition)
-  ndf <- add_trans_prob(ndf_in, pam_msm, ci = T)
+  ndf <- add_trans_prob(ndf_in, pam_msm, ci = TRUE)
   n_groups <- dplyr::n_distinct(ndf_in$transition)
   expect_data_frame(ndf, nrows = nrow(ndf_in) + n_groups, ncols = 6L)
   expect_subset(c("trans_prob", "trans_lower", "trans_upper"), colnames(ndf))

--- a/tests/testthat/test-add-functions.R
+++ b/tests/testthat/test-add-functions.R
@@ -223,7 +223,7 @@ test_that("cumulative hazard function works for arbitrary time points", {
 
   expect_equal(ndf1$cumu_hazard[3], ndf2$cumu_hazard[1])
   expect_equal(ndf1$cumu_hazard[6], ndf2$cumu_hazard[2])
-  
+
   #without grouping
   set.seed(211758)
   df <- data.frame(
@@ -236,19 +236,18 @@ test_that("cumulative hazard function works for arbitrary time points", {
   tmax = max(ped_sim$tend)
   ndf1 <- ped_sim %>%
     make_newdata(tend = unique(tend)) %>%
-    add_cumu_hazard(pam_sim) |> 
+    add_cumu_hazard(pam_sim) |>
     dplyr::filter(tend == tmax)
-  
+
   ndf2 <- ped_sim %>%
     make_newdata(tend = c(2, tmax)) %>%
     add_cumu_hazard(pam_sim) |>
     dplyr::filter(tend == tmax)
-  
+
   expect_message(
     ped_sim %>% make_newdata(tend = c(2, tmax))
   )
   expect_equal(ndf1$cumu_hazard, ndf2$cumu_hazard, tolerance = 0.1)
-  
 })
 
 test_that("cumulative hazard functions work for PEM", {
@@ -463,17 +462,18 @@ test_that("survival probabilities functions work for PAM", {
 
   expect_data_frame(
     add_surv_prob(ped_info(ped), bam, ci = FALSE),
-    nrows = 5L,
+    nrows = 6L,
     ncols = 8L
   )
   expect_data_frame(
     surv <- add_surv_prob(ped_info(ped), pam, ci = FALSE),
-    nrows = 5L,
+    nrows = 6L,
     ncols = 8L
   )
+  expect_false(any(c("surv_lower", "surv_upper") %in% names(surv)))
   expect_data_frame(
     surv <- add_surv_prob(ped_info(ped), pam),
-    nrows = 5L,
+    nrows = 6L,
     ncols = 10L
   )
   stest <- sapply(
@@ -483,15 +483,25 @@ test_that("survival probabilities functions work for PAM", {
     }
   )
   expect_identical(all(stest), TRUE)
-  expect_identical(round(surv$surv_prob, 2), c(0.97, 0.94, 0.88, 0.83, 0.79))
-  expect_identical(round(surv$surv_lower, 2), c(0.95, 0.90, 0.83, 0.76, 0.68))
-  expect_identical(round(surv$surv_upper, 2), c(0.98, 0.96, 0.92, 0.89, 0.86))
+  expect_identical(surv$tend[1], 0)
+  expect_identical(surv$intlen[1], 0)
+  expect_identical(round(surv$surv_prob, 2), c(1, 0.97, 0.94, 0.88, 0.83, 0.79))
+  expect_identical(
+    round(surv$surv_lower, 2),
+    c(1, 0.95, 0.90, 0.83, 0.76, 0.68)
+  )
+  expect_identical(
+    round(surv$surv_upper, 2),
+    c(1, 0.98, 0.96, 0.92, 0.89, 0.86)
+  )
   # check that overwrite works
+  surv_over <- add_surv_prob(surv, pam, overwrite = TRUE)
   expect_data_frame(
-    add_surv_prob(surv, pam, overwrite = TRUE),
-    nrows = 5L,
+    surv_over,
+    nrows = 6L,
     ncols = 10L
   )
+  expect_equal(sum(surv_over$tend == 0), 1L)
   # error on wrong input
   expect_error(add_surv_prob(surv, pam))
 
@@ -500,22 +510,31 @@ test_that("survival probabilities functions work for PAM", {
     group_by(complications) %>%
     ped_info() %>%
     add_surv_prob(pam)
-  expect_data_frame(grouped_surv, nrows = 10L, ncols = 10L)
+  expect_data_frame(grouped_surv, nrows = 12L, ncols = 10L)
   expect_equal(
     round(grouped_surv$surv_prob, 2),
-    c(0.97, 0.94, 0.88, .83, .79, .94, 0.88, .78, .69, .61)
+    c(1, 0.97, 0.94, 0.88, .83, .79, 1, .94, 0.88, .78, .69, .61)
   )
 
   ## delta CI
   surv2 <- add_surv_prob(ped_info(ped), pam, ci_type = "delta")
-  expect_equal(round(surv2$surv_lower, 2), c(.95, .91, .84, .78, .72))
-  expect_equal(round(surv2$surv_upper, 2), c(.99, .97, .93, .89, .86))
+  expect_equal(round(surv2$surv_lower, 2), c(1, .95, .91, .84, .78, .72))
+  expect_equal(round(surv2$surv_upper, 2), c(1, .99, .97, .93, .89, .86))
 
   # sim CI
   set.seed(123)
   surv3 <- add_surv_prob(ped_info(ped), pam, ci_type = "sim")
-  expect_equal(round(surv3$surv_lower, 2), c(.94, .90, .83, .78, .71))
-  expect_equal(round(surv3$surv_upper, 2), c(.98, .96, .92, .88, .84))
+  expect_equal(round(surv3$surv_lower, 2), c(1, .94, .90, .83, .78, .71))
+  expect_equal(round(surv3$surv_upper, 2), c(1, .98, .96, .92, .88, .84))
+})
+
+test_that("cumulative boundary helpers preserve non-boundary NA times", {
+  x <- tibble::tibble(tend = c(0, NA_real_, 1), value = 1:3)
+
+  out <- pammtools:::drop_cumulative_boundary(x, "tend")
+
+  expect_equal(out$tend, c(NA_real_, 1))
+  expect_equal(out$value, 2:3)
 })
 
 test_that("CIF works with pamm", {
@@ -527,17 +546,30 @@ test_that("CIF works with pamm", {
   ped_cr <- as_ped(df, Surv(time, status) ~ ., id = "id") %>%
     mutate(cause = as.factor(cause))
   pam <- pamm(ped_status ~ s(tend, by = cause), data = ped_cr)
-  ndf <- ped_cr %>%
+  ndf_in <- ped_cr %>%
     make_newdata(tend = unique(tend), cause = unique(cause)) %>%
-    group_by(cause) %>%
-    add_cif(pam)
-  expect_data_frame(ndf, nrows = 26L, ncols = 7L)
+    group_by(cause)
+  n_groups <- dplyr::n_distinct(ndf_in$cause)
+  ndf <- add_cif(ndf_in, pam)
+  expect_data_frame(ndf, nrows = nrow(ndf_in) + n_groups, ncols = 7L)
   expect_subset(c("cif", "cif_lower", "cif_upper"), colnames(ndf))
+  expect_equal(sum(ndf$tend == 0), n_groups)
+  expect_true(all(ndf$cif[ndf$tend == 0] == 0))
+  expect_true(all(ndf$cif_lower[ndf$tend == 0] == 0))
+  expect_true(all(ndf$cif_upper[ndf$tend == 0] == 0))
+  expect_equal(attr(ndf, "trafo_args"), attr(ndf_in, "trafo_args"))
+  expect_equal(attr(ndf, "intvars"), attr(ndf_in, "intvars"))
+  expect_equal(dplyr::group_vars(ndf), dplyr::group_vars(ndf_in))
   expect_true(all(ndf$cif <= ndf$cif_upper))
   expect_true(all(ndf$cif >= ndf$cif_lower))
   expect_true(all(ndf$cif <= 1 & ndf$cif >= 0))
   expect_true(all(ndf$cif_lower <= 1 & ndf$cif_lower >= 0))
   expect_true(all(ndf$cif_upper <= 1 & ndf$cif_upper >= 0))
+
+  expect_error(add_cif(ndf, pam))
+  ndf_over <- add_cif(ndf, pam, overwrite = TRUE)
+  expect_data_frame(ndf_over, nrows = nrow(ndf_in) + n_groups, ncols = 7L)
+  expect_equal(sum(ndf_over$tend == 0), n_groups)
 })
 
 
@@ -559,25 +591,36 @@ test_that("CIF works with arbitrary time points", {
   ndf1 <- ped_cr %>%
     make_newdata(tend = unique(tend), cause = unique(cause)) |>
     group_by(cause) |>
-    add_cif(pam, ci=FALSE) |>
+    add_cif(pam, ci = FALSE) |>
     dplyr::filter(tend == tmax)
 
-  ndf2 <- ped_cr %>%
+  ndf2_in <- ped_cr %>%
     make_newdata(tend = c(2, tmax), cause = unique(cause)) %>%
-    group_by(cause) |>
-    add_cif(pam, ci=FALSE)
+    group_by(cause)
+  ndf2 <- add_cif(ndf2_in, pam, ci = FALSE)
 
   expect_message(
     ped_cr %>% make_newdata(tend = c(2, tmax), cause = unique(cause))
   )
-  expect_equal(ndf1$cif, ndf2 |> dplyr::filter(tend == tmax) |> pull(cif), tolerance = 0.1)
-  expect_data_frame(ndf2, nrows = 4L, ncols = 5L)
+  expect_equal(
+    ndf1$cif,
+    ndf2 |> dplyr::filter(tend == tmax) |> pull(cif),
+    tolerance = 0.1
+  )
+  expect_data_frame(
+    ndf2,
+    nrows = nrow(ndf2_in) + dplyr::n_distinct(ndf2_in$cause),
+    ncols = 5L
+  )
+  expect_false(any(c("cif_lower", "cif_upper") %in% names(ndf2)))
+  expect_equal(sum(ndf2$tend == 0), dplyr::n_distinct(ndf2_in$cause))
+  expect_true(all(ndf2$cif[ndf2$tend == 0] == 0))
 })
 
 test_that("add_cif returns same grid as add_cumu_hazard", {
   set.seed(211758)
   df <- data.frame(
-    time   = rexp(20),
+    time = rexp(20),
     status = sample(c(0, 1, 2), 20, replace = TRUE)
   )
   ped_cr <- as_ped(df, Surv(time, status) ~ ., id = "id") %>%
@@ -589,27 +632,33 @@ test_that("add_cif returns same grid as add_cumu_hazard", {
     cuts <- attr(ped, "trafo_args")[["cut"]]
     setdiff(cuts[cuts <= tmax], 0)
   }
-  tmax       <- max(ped_cr$tend)
-  full_grid  <- cuts_le_tmax(ped_cr, tmax)
+  tmax <- max(ped_cr$tend)
+  full_grid <- cuts_le_tmax(ped_cr, tmax)
   sparse_tend <- c(2, tmax) # deliberately misses interior breakpoints
 
-  # ---- add_cif: returns the expanded grid (more rows than requested) ----
+  # ---- add_cif: returns requested rows plus one boundary row per cause ----
   nd_cif_in <- ped_cr %>%
     make_newdata(tend = sparse_tend, cause = unique(cause)) %>%
     group_by(cause)
   nd_cif_out <- add_cif(nd_cif_in, pam_cr, ci = FALSE)
 
-  expect_equal(nrow(nd_cif_out), nrow(nd_cif_in))
+  expect_equal(
+    nrow(nd_cif_out),
+    nrow(nd_cif_in) + dplyr::n_distinct(nd_cif_in$cause)
+  )
+  expect_equal(sum(nd_cif_out$tend == 0), dplyr::n_distinct(nd_cif_in$cause))
   # all cut-grid breakpoints up to max requested time must be present
   expect_false(all(full_grid %in% unique(nd_cif_out$tend)))
 
   # ---- add_cumu_hazard: returns rows matching the requested newdata ----
-  df_single <- data.frame(time = rexp(20),
-                          status = sample(c(0, 1), 20, replace = TRUE))
-  ped       <- as_ped(df_single, Surv(time, status) ~ ., id = "id")
-  pam       <- pamm(ped_status ~ s(tend), data = ped)
+  df_single <- data.frame(
+    time = rexp(20),
+    status = sample(c(0, 1), 20, replace = TRUE)
+  )
+  ped <- as_ped(df_single, Surv(time, status) ~ ., id = "id")
+  pam <- pamm(ped_status ~ s(tend), data = ped)
 
-  nd_cuh_in  <- ped %>% make_newdata(tend = c(2, max(ped$tend)))
+  nd_cuh_in <- ped %>% make_newdata(tend = c(2, max(ped$tend)))
   nd_cuh_out <- add_cumu_hazard(nd_cuh_in, pam)
 
   expect_equal(nrow(nd_cuh_out), nrow(nd_cuh_in))
@@ -630,12 +679,18 @@ test_that("CIF works with mgcv::gam", {
     family = poisson(),
     offset = offset
   )
-  ndf <- ped_cr %>%
+  ndf_in <- ped_cr %>%
     make_newdata(tend = unique(tend), cause = unique(cause)) %>%
-    group_by(cause) %>%
-    add_cif(pam)
-  expect_data_frame(ndf, nrows = 26L, ncols = 7L)
+    group_by(cause)
+  ndf <- add_cif(ndf_in, pam)
+  expect_data_frame(
+    ndf,
+    nrows = nrow(ndf_in) + dplyr::n_distinct(ndf_in$cause),
+    ncols = 7L
+  )
   expect_subset(c("cif", "cif_lower", "cif_upper"), colnames(ndf))
+  expect_equal(sum(ndf$tend == 0), dplyr::n_distinct(ndf_in$cause))
+  expect_true(all(ndf$cif[ndf$tend == 0] == 0))
   expect_true(all(ndf$cif <= ndf$cif_upper))
   expect_true(all(ndf$cif >= ndf$cif_lower))
   expect_true(all(ndf$cif <= 1 & ndf$cif >= 0))
@@ -664,8 +719,13 @@ test_that("CIF works with nonstandard time variable names", {
   set.seed(211758)
   ndf <- ndf_stop %>%
     add_cif(pam, time_var = "stop", ci = FALSE, nsim = 20L)
-  expect_data_frame(ndf, nrows = 26L)
+  expect_data_frame(
+    ndf,
+    nrows = nrow(ndf_stop) + dplyr::n_distinct(ndf_stop$cause)
+  )
   expect_subset(c("cif"), colnames(ndf))
+  expect_equal(sum(ndf$stop == 0), dplyr::n_distinct(ndf_stop$cause))
+  expect_true(all(ndf$cif[ndf$stop == 0] == 0))
   expect_true(all(ndf$cif <= 1 & ndf$cif >= 0))
 
   set.seed(211758)
@@ -693,12 +753,18 @@ test_that("CIF works with character causes", {
   ped_cr <- as_ped(df, Surv(time, status) ~ ., id = "id") %>%
     mutate(cause = factor(cause, labels = c("Death", "Discharge")))
   pam <- pamm(ped_status ~ s(tend, by = cause), data = ped_cr)
-  ndf <- ped_cr %>%
+  ndf_in <- ped_cr %>%
     make_newdata(tend = unique(tend), cause = unique(cause)) %>%
-    group_by(cause) %>%
-    add_cif(pam)
-  expect_data_frame(ndf, nrows = 26L, ncols = 7L)
+    group_by(cause)
+  ndf <- add_cif(ndf_in, pam)
+  expect_data_frame(
+    ndf,
+    nrows = nrow(ndf_in) + dplyr::n_distinct(ndf_in$cause),
+    ncols = 7L
+  )
   expect_subset(c("cif", "cif_lower", "cif_upper"), colnames(ndf))
+  expect_equal(sum(ndf$tend == 0), dplyr::n_distinct(ndf_in$cause))
+  expect_true(all(ndf$cif[ndf$tend == 0] == 0))
   expect_true(all(ndf$cif <= ndf$cif_upper))
   expect_true(all(ndf$cif >= ndf$cif_lower))
   expect_true(all(ndf$cif <= 1 & ndf$cif >= 0))
@@ -707,104 +773,127 @@ test_that("CIF works with character causes", {
 })
 
 test_that("CIF works with non-default cause_var names", {
-
   set.seed(211758)
-  df <- data.frame(time = rexp(20), status = sample(c(0, 1, 2), 20, replace = TRUE))
+  df <- data.frame(
+    time = rexp(20),
+    status = sample(c(0, 1, 2), 20, replace = TRUE)
+  )
   ped_cr <- as_ped(df, Surv(time, status) ~ ., id = "id") %>%
     mutate(event_type = factor(cause, labels = c("Death", "Discharge"))) %>%
     select(-cause)
   pam <- pamm(ped_status ~ s(tend, by = event_type), data = ped_cr)
-  ndf <- ped_cr %>%
+  ndf_in <- ped_cr %>%
     make_newdata(tend = unique(tend), event_type = unique(event_type)) %>%
-    group_by(event_type) %>%
-    add_cif(pam, cause_var = "event_type")
+    group_by(event_type)
+  ndf <- add_cif(ndf_in, pam, cause_var = "event_type")
 
-  expect_data_frame(ndf, nrows = 26L, ncols = 7L)
+  expect_data_frame(
+    ndf,
+    nrows = nrow(ndf_in) + dplyr::n_distinct(ndf_in$event_type),
+    ncols = 7L
+  )
   expect_subset(c("cif", "cif_lower", "cif_upper"), colnames(ndf))
+  expect_equal(sum(ndf$tend == 0), dplyr::n_distinct(ndf_in$event_type))
+  expect_true(all(ndf$cif[ndf$tend == 0] == 0))
   expect_true(all(ndf$cif <= 1 & ndf$cif >= 0))
   expect_true(all(ndf$cif_lower <= 1 & ndf$cif_lower >= 0))
   expect_true(all(ndf$cif_upper <= 1 & ndf$cif_upper >= 0))
-
 })
 
 test_that("CIF uses exact within-interval exponential integral", {
   set.seed(211758)
-  df <- data.frame(time = rexp(20), status = sample(c(0, 1, 2), 20, replace = TRUE))
+  df <- data.frame(
+    time = rexp(20),
+    status = sample(c(0, 1, 2), 20, replace = TRUE)
+  )
   ped_cr <- as_ped(df, Surv(time, status) ~ ., id = "id") %>%
     mutate(cause = as.factor(cause))
   pam <- pamm(ped_status ~ s(tend, by = cause), data = ped_cr)
-  
+
   cut_points <- unique(ped_cr$tend)[unique(ped_cr$tend) <= 0.5]
-  
+
   ndf <- ped_cr %>%
     make_newdata(tend = c(cut_points, 0.5), cause = unique(cause)) %>%
     group_by(cause)
-  
+
   target_cause <- levels(ndf$cause)[1]
   ndf_target <- ndf %>%
     filter(cause == target_cause) %>%
     arrange(tend) %>%
     reconstruct_intlen()
-  
+
   causes_model <- levels(ndf$cause)
-  
+
   # Predict cause-specific hazards at posterior mean (no simulation)
-  hazards_manual <- map(causes_model, ~ {
-    .df <- mutate(ndf_target, cause = factor(.x, levels = causes_model))
-    as.numeric(predict(pam, .df, type = "response"))
-  })
+  hazards_manual <- map(
+    causes_model,
+    ~ {
+      .df <- mutate(ndf_target, cause = factor(.x, levels = causes_model))
+      as.numeric(predict(pam, .df, type = "response"))
+    }
+  )
   names(hazards_manual) <- causes_model
-  
-  intlen    <- ndf_target$intlen
-  n         <- length(intlen)
-  hk        <- hazards_manual[[target_cause]]          # cause-specific hazard
-  hj        <- Reduce("+", hazards_manual)             # all-cause hazard (vector)
-  
+
+  intlen <- ndf_target$intlen
+  n <- length(intlen)
+  hk <- hazards_manual[[target_cause]] # cause-specific hazard
+  hj <- Reduce("+", hazards_manual) # all-cause hazard (vector)
+
   # Recursive exact CIF using the closed-form per-interval integral
-  S   <- numeric(n)   # S(kappa_{j-1}), i.e. survival at START of interval j
-  cif <- numeric(n)   # F_k(kappa_j)
-  
-  S_prev   <- 1
+  S <- numeric(n) # S(kappa_{j-1}), i.e. survival at START of interval j
+  cif <- numeric(n) # F_k(kappa_j)
+
+  S_prev <- 1
   cif_prev <- 0
-  
+
   for (j in seq_len(n)) {
-    delta_cif  <- (hk[j] / hj[j]) * S_prev * (1 - exp(-hj[j] * intlen[j]))
-    cif[j]     <- cif_prev + delta_cif
-    S_prev     <- S_prev * exp(-hj[j] * intlen[j])
-    cif_prev   <- cif[j]
+    delta_cif <- (hk[j] / hj[j]) * S_prev * (1 - exp(-hj[j] * intlen[j]))
+    cif[j] <- cif_prev + delta_cif
+    S_prev <- S_prev * exp(-hj[j] * intlen[j])
+    cif_prev <- cif[j]
   }
-  
+
   observed <- ndf %>%
     add_cif(pam, ci = FALSE) %>%
     filter(cause == target_cause) %>%
     arrange(tend)
-  
-  expect_equal(observed$cif, cif, tolerance = 1e-8)
-  
+
+  cif_with_boundary <- c(0, cif)
+  expect_equal(observed$cif, cif_with_boundary, tolerance = 1e-8)
+
   observed <- ndf %>%
     add_cif(pam, ci = TRUE) %>%
     filter(cause == target_cause) %>%
     arrange(tend)
-  
+
   expect_true(all(
-    cif >= observed$cif_lower &
-    cif <= observed$cif_upper
+    cif_with_boundary >= observed$cif_lower &
+      cif_with_boundary <= observed$cif_upper
   ))
-  
 })
 
 test_that("Transition Probability works", {
-  ndf <- ped_msm %>%
+  ndf_in <- ped_msm %>%
     make_newdata(tend = unique(tend), transition = unique(transition)) %>%
-    group_by(transition) %>%
-    add_trans_prob(pam_msm, ci = T)
-  expect_data_frame(ndf, nrows = 380L, ncols = 6L)
+    group_by(transition)
+  ndf <- add_trans_prob(ndf_in, pam_msm, ci = T)
+  n_groups <- dplyr::n_distinct(ndf_in$transition)
+  expect_data_frame(ndf, nrows = nrow(ndf_in) + n_groups, ncols = 6L)
   expect_subset(c("trans_prob", "trans_lower", "trans_upper"), colnames(ndf))
-  expect_true(all(ndf$trans_prob < ndf$trans_upper))
-  expect_true(all(ndf$trans_prob > ndf$trans_lower))
+  expect_equal(sum(ndf$tend == 0), n_groups)
+  expect_true(all(ndf$trans_prob[ndf$tend == 0] == 0))
+  expect_true(all(ndf$trans_lower[ndf$tend == 0] == 0))
+  expect_true(all(ndf$trans_upper[ndf$tend == 0] == 0))
+  expect_true(all(ndf$trans_prob[ndf$tend > 0] < ndf$trans_upper[ndf$tend > 0]))
+  expect_true(all(ndf$trans_prob[ndf$tend > 0] > ndf$trans_lower[ndf$tend > 0]))
   expect_true(all(ndf$trans_prob <= 1 & ndf$trans_prob >= 0))
   expect_true(all(ndf$trans_lower <= 1 & ndf$trans_lower >= 0))
   expect_true(all(ndf$trans_upper <= 1 & ndf$trans_upper >= 0))
+
+  expect_error(add_trans_prob(ndf, pam_msm, ci = TRUE))
+  ndf_over <- add_trans_prob(ndf, pam_msm, ci = TRUE, overwrite = TRUE)
+  expect_data_frame(ndf_over, nrows = nrow(ndf_in) + n_groups, ncols = 6L)
+  expect_equal(sum(ndf_over$tend == 0), n_groups)
 })
 
 test_that("transition probabilities remain bounded and confidence intervals ordered", {
@@ -857,9 +946,11 @@ test_that("Transition Probability works with nonstandard time and interval colum
 
   expect_data_frame(
     tp <- add_trans_prob(ndf_stop, pam_msm_stop, ci = FALSE, time_var = "stop"),
-    nrows = 380L
+    nrows = nrow(ndf_stop) + dplyr::n_distinct(ndf_stop$transition)
   )
   expect_subset(c("trans_prob"), colnames(tp))
+  expect_equal(sum(tp$stop == 0), dplyr::n_distinct(ndf_stop$transition))
+  expect_true(all(tp$trans_prob[tp$stop == 0] == 0))
   expect_true(all(tp$trans_prob <= 1 & tp$trans_prob >= 0))
 
   ndf_stop_len <- reconstruct_intlen(ndf_stop, time_var = "stop") %>%
@@ -875,9 +966,11 @@ test_that("Transition Probability works with nonstandard time and interval colum
       time_var = "stop",
       interval_length = "length"
     ),
-    nrows = 380L
+    nrows = nrow(ndf_stop_len) + dplyr::n_distinct(ndf_stop_len$transition)
   )
   expect_subset(c("trans_prob", "trans_lower", "trans_upper"), colnames(tp_ci))
+  expect_equal(sum(tp_ci$stop == 0), dplyr::n_distinct(ndf_stop_len$transition))
+  expect_true(all(tp_ci$trans_prob[tp_ci$stop == 0] == 0))
   expect_true(all(tp_ci$trans_prob <= 1 & tp_ci$trans_prob >= 0))
 
   ped_msm_stop_trans <- rename(ped_msm, stop = tend, trans = transition)
@@ -902,9 +995,11 @@ test_that("Transition Probability works with nonstandard time and interval colum
       interval_length = "length",
       transition = "trans"
     ),
-    nrows = 380L
+    nrows = nrow(ndf_stop_trans) + dplyr::n_distinct(ndf_stop_trans$trans)
   )
   expect_subset(c("trans_prob"), colnames(tp_trans))
+  expect_equal(sum(tp_trans$stop == 0), dplyr::n_distinct(ndf_stop_trans$trans))
+  expect_true(all(tp_trans$trans_prob[tp_trans$stop == 0] == 0))
   expect_true(all(tp_trans$trans_prob <= 1 & tp_trans$trans_prob >= 0))
 })
 
@@ -935,14 +1030,16 @@ test_that("Transition Probability is invariant to input row order", {
 test_that("transition_state_table parses arrow-notation integer states", {
   out <- pammtools:::transition_state_table(c("1->2", "1->3", "2->3"))
   expect_equal(out$from_int, c(1L, 1L, 2L))
-  expect_equal(out$to_int,   c(2L, 3L, 3L))
+  expect_equal(out$to_int, c(2L, 3L, 3L))
 })
 
 test_that("transition_state_table shifts state indices when minimum is 0", {
   shifted <- pammtools:::transition_state_table(c("0->1", "0->2", "1->2"))
   unshifted <- pammtools:::transition_state_table(c("1->2", "1->3", "2->3"))
-  expect_equal(shifted[, c("from_int", "to_int")],
-               unshifted[, c("from_int", "to_int")])
+  expect_equal(
+    shifted[, c("from_int", "to_int")],
+    unshifted[, c("from_int", "to_int")]
+  )
 })
 
 test_that("transition_state_table encodes character states by sorted unique name", {
@@ -951,14 +1048,18 @@ test_that("transition_state_table encodes character states by sorted unique name
   )
   # alphabetical: death=1, healthy=2, ill=3
   expect_equal(out$from_int, c(2L, 2L, 3L))
-  expect_equal(out$to_int,   c(3L, 1L, 1L))
+  expect_equal(out$to_int, c(3L, 1L, 1L))
 })
 
 test_that("transition_state_table errors on malformed labels", {
-  expect_error(pammtools:::transition_state_table(c("1->2", "broken")),
-               "Each transition must look like")
-  expect_error(pammtools:::transition_state_table(c("1->2->3")),
-               "Each transition must look like")
+  expect_error(
+    pammtools:::transition_state_table(c("1->2", "broken")),
+    "Each transition must look like"
+  )
+  expect_error(
+    pammtools:::transition_state_table(c("1->2->3")),
+    "Each transition must look like"
+  )
 })
 
 test_that("transition_state_table deduplicates and handles factor input", {
@@ -971,22 +1072,35 @@ test_that("transition_state_table deduplicates and handles factor input", {
 # --- end-to-end add_trans_prob across state encodings ---------------------
 test_that("add_trans_prob works for state encodings: int>=1, int>=0, named", {
   prep_msm <- function(map_states) {
-    df <- prothr[, ] |>
-      mutate(from = map_states(from), to = map_states(to),
-             transition = as.factor(paste0(from, "->", to)))
-    ped <- as_ped(df, formula = Surv(Tstart, Tstop, status) ~ .,
-      transition = "transition", id = "id", timescale = "calendar")
-    pam <- gam(ped_status ~ s(tend, by = transition, bs = "cr") + transition,
-      data = ped, family = poisson(), offset = offset)
+    df <- prothr[,] |>
+      mutate(
+        from = map_states(from),
+        to = map_states(to),
+        transition = as.factor(paste0(from, "->", to))
+      )
+    ped <- as_ped(
+      df,
+      formula = Surv(Tstart, Tstop, status) ~ .,
+      transition = "transition",
+      id = "id",
+      timescale = "calendar"
+    )
+    pam <- gam(
+      ped_status ~ s(tend, by = transition, bs = "cr") + transition,
+      data = ped,
+      family = poisson(),
+      offset = offset
+    )
     ndf <- ped %>%
       make_newdata(tend = unique(tend), transition = unique(transition)) %>%
-      group_by(transition) %>% add_trans_prob(pam, ci = FALSE)
+      group_by(transition) %>%
+      add_trans_prob(pam, ci = FALSE)
     list(ndf = ndf, ped = ped)
   }
 
-  res_1 <- prep_msm(identity)                                  # states 1,2,3
-  res_0 <- prep_msm(function(s) s - 1L)                        # states 0,1,2
-  res_n <- prep_msm(function(s) c("a", "b", "c")[s])           # named states
+  res_1 <- prep_msm(identity) # states 1,2,3
+  res_0 <- prep_msm(function(s) s - 1L) # states 0,1,2
+  res_n <- prep_msm(function(s) c("a", "b", "c")[s]) # named states
 
   # all runs complete, no NAs, all in [0,1]
   for (r in list(res_1, res_0, res_n)) {
@@ -996,17 +1110,29 @@ test_that("add_trans_prob works for state encodings: int>=1, int>=0, named", {
 
   # integer state encodings starting at 0 vs 1 produce identical numerics
   # (matched per matching transition label after relabeling)
-  rename_trans <- function(lbl) sub("^0", "1", sub("->0", "->1",
-                                  sub("1", "2", sub("->1", "->2",
-                                  sub("2", "3", sub("->2", "->3", lbl))))))
+  rename_trans <- function(lbl)
+    sub(
+      "^0",
+      "1",
+      sub(
+        "->0",
+        "->1",
+        sub("1", "2", sub("->1", "->2", sub("2", "3", sub("->2", "->3", lbl))))
+      )
+    )
   v_1 <- with(res_1$ndf, setNames(trans_prob, paste(tend, transition)))
-  v_0 <- with(res_0$ndf,
-    setNames(trans_prob, paste(tend, rename_trans(as.character(transition)))))
+  v_0 <- with(
+    res_0$ndf,
+    setNames(trans_prob, paste(tend, rename_trans(as.character(transition))))
+  )
   expect_equal(sort(v_1), sort(v_0))
 
   # named encoding gives the same set of trans_prob values up to relabeling
-  expect_equal(sort(res_n$ndf$trans_prob), sort(res_1$ndf$trans_prob),
-               tolerance = 1e-10)
+  expect_equal(
+    sort(res_n$ndf$trans_prob),
+    sort(res_1$ndf$trans_prob),
+    tolerance = 1e-10
+  )
 
   # from/to garbage columns are stripped from output
   for (r in list(res_1, res_0, res_n)) {


### PR DESCRIPTION
## Summary

Adds plotting boundary rows for cumulative prediction-grid outputs:

- `add_surv_prob()` now returns one `time_var == 0` row per group with `S(0) = 1` and collapsed confidence bounds when requested.
- `add_cif()` now returns one `time_var == 0` row per group with `CIF(0) = 0` and collapsed confidence bounds when requested.
- `add_trans_prob()` now returns one `time_var == 0` row per group and transition with off-diagonal transition probability `0` and collapsed confidence bounds when requested.

The helpers drop existing boundary rows on overwrite/recompute, preserve prediction-grid metadata, keep non-boundary `NA` time rows, and document that `add_cumu_hazard()` keeps the original prediction grid.

## Validation

- `air format R/add-functions.R tests/testthat/test-add-functions.R`
- `Rscript -e "devtools::document()"` (completed; emitted existing roxygen S3-method diagnostics)
- `Rscript -e "devtools::test()"` -> 614 pass, 0 fail, 0 warn
- `git diff --check`