### PR TITLE
Use type-6 quantiles for simulation-based CIs (fixes #288)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,17 @@
 # pammtools 0.7.6
 
 ## Bug fixes
+* Simulation-based confidence intervals (`ci_type = "sim"` in `add_hazard()`,
+  `add_cumu_hazard()`, `add_surv_prob()`, as well as `add_cif()`,
+  `add_trans_prob()`/`add_trans_ci()` and the cumulative hazard differences
+  in `get_cumu_coef()`) now use type-6 empirical quantiles instead of the
+  `stats::quantile()` default (type 7). Type-7 quantiles made these intervals
+  systematically too narrow for small `nsim`: at the default `nsim = 100`,
+  the expected central mass of the draws enclosed by the bounds is ~93%
+  instead of the nominal 95%. Type-6 quantiles remove this systematic
+  inward bias (#288). As a consequence, all simulation-based CI bounds
+  change slightly (intervals widen at both ends) relative to versions
+  <= 0.7.5.
 * `add_trans_prob()` and `add_trans_ci()` no longer require the input data to
   be pre-sorted; the internal `arrange` call is now handled automatically,
   fixing the user-facing sorting dependency reported in #255 and related to

--- a/R/add-functions.R
+++ b/R/add-functions.R
@@ -189,7 +189,16 @@ resolve_time_var <- function(time_var, object, newdata) {
 #' error calculated by the Delta method. \code{"sim"} draws the
 #' property of interest from its posterior based on the normal distribution of
 #' the estimated coefficients. See \href{https://adibender.github.io/simpamm/confidence-intervals.html}{here}
-#' for details and empirical evaluation.
+#' for details and empirical evaluation. For \code{ci_type = "sim"}, interval
+#' bounds are empirical quantiles (type 6, see \code{\link[stats]{quantile}})
+#' of \code{nsim} posterior draws (default \code{nsim = 100L}, passed via
+#' \code{...}). Type-6 quantiles avoid the systematic inward bias that the
+#' \code{\link[stats]{quantile}} default (type 7) exhibits for small
+#' \code{nsim}, but at the default \code{nsim = 100} the bounds are estimated
+#' from few tail draws and thus noisy; increase \code{nsim} (e.g., to 500 or
+#' more) for more stable interval bounds. Very small \code{nsim}
+#' (\code{nsim < 2 / alpha - 1}, i.e., below 39 for \code{alpha = 0.05})
+#' cannot achieve the nominal level at all.
 #' @param se_mult Factor by which standard errors are multiplied for calculating
 #' the confidence intervals.
 #' @param overwrite Should hazard columns be overwritten if already present in
@@ -775,8 +784,8 @@ get_sim_ci <- function(newdata, object, alpha = 0.05, nsim = 100L, ...) {
   sim_coef_mat <- mvtnorm::rmvnorm(nsim, mean = coefs, sigma = V)
   sim_fit_mat <- apply(sim_coef_mat, 1, function(z) exp(X %*% z))
 
-  newdata$ci_lower <- apply(sim_fit_mat, 1, quantile, probs = alpha / 2)
-  newdata$ci_upper <- apply(sim_fit_mat, 1, quantile, probs = 1 - alpha / 2)
+  newdata$ci_lower <- apply(sim_fit_mat, 1, quantile, probs = alpha / 2, type = 6)
+  newdata$ci_upper <- apply(sim_fit_mat, 1, quantile, probs = 1 - alpha / 2, type = 6)
 
   newdata
 }
@@ -802,8 +811,8 @@ get_sim_ci_cumu <- function(
     function(z) cumsum(intlen * exp(X %*% z))
   )
 
-  newdata$cumu_lower <- apply(sim_fit_mat, 1, quantile, probs = alpha / 2)
-  newdata$cumu_upper <- apply(sim_fit_mat, 1, quantile, probs = 1 - alpha / 2)
+  newdata$cumu_lower <- apply(sim_fit_mat, 1, quantile, probs = alpha / 2, type = 6)
+  newdata$cumu_upper <- apply(sim_fit_mat, 1, quantile, probs = 1 - alpha / 2, type = 6)
 
   newdata
 }
@@ -828,8 +837,8 @@ get_sim_ci_surv <- function(
     function(z) exp(-cumsum(intlen * exp(X %*% z)))
   )
 
-  newdata$surv_lower <- apply(sim_fit_mat, 1, quantile, probs = alpha / 2)
-  newdata$surv_upper <- apply(sim_fit_mat, 1, quantile, probs = 1 - alpha / 2)
+  newdata$surv_lower <- apply(sim_fit_mat, 1, quantile, probs = alpha / 2, type = 6)
+  newdata$surv_upper <- apply(sim_fit_mat, 1, quantile, probs = 1 - alpha / 2, type = 6)
 
   newdata
 }
@@ -843,7 +852,8 @@ get_sim_ci_surv <- function(
 #' @param alpha The alpha level for confidence/credible intervals.
 #' @param nsim Number of simulations (draws from posterior of estimated coefficients)
 #' on which estimation of CIFs and their confidence/credible intervals will be
-#' based on.
+#' based on. Interval bounds are empirical type-6 quantiles of the \code{nsim}
+#' draws; larger values of \code{nsim} yield more stable interval bounds.
 #' @param cause_var Character. Column name of the 'cause' variable.
 #' @param interval_length \code{Character}, defaults to \code{"intlen"}.
 #'   contains the interval length in `newdata`.
@@ -1016,8 +1026,8 @@ get_cif.default <- function(
   
   newdata[["cif"]] <- pmin(pmax(rowMeans(cifs), 0), 1)
   if (ci) {
-    newdata[["cif_lower"]] <- pmin(pmax(apply(cifs, 1, quantile, alpha / 2, na.rm = TRUE), 0), 1)
-    newdata[["cif_upper"]] <- pmin(pmax(apply(cifs, 1, quantile, 1 - alpha / 2, na.rm = TRUE), 0), 1)
+    newdata[["cif_lower"]] <- pmin(pmax(apply(cifs, 1, quantile, probs = alpha / 2, na.rm = TRUE, type = 6), 0), 1)
+    newdata[["cif_upper"]] <- pmin(pmax(apply(cifs, 1, quantile, probs = 1 - alpha / 2, na.rm = TRUE, type = 6), 0), 1)
   }
 
   newdata
@@ -1220,7 +1230,9 @@ transition_state_table <- function(transitions, sep = "->") {
 #' intervals for transition probabilities are calculated.
 #' @param alpha Sets the confidence intervals' \eqn{\alpha} level, Defaults to \code{0.05}
 #' @param nsim Sets the number of iterations for simulated confidence intervals.
-#' Defaults to \code{100L}
+#' Defaults to \code{100L}. Interval bounds are empirical type-6 quantiles of
+#' the \code{nsim} draws; larger values of \code{nsim} yield more stable
+#' interval bounds.
 #' @param time_var Name of the variable used for the baseline hazard. Defaults
 #'   to \code{"tend"}.
 #' @param interval_length \code{Character}, defaults to \code{"intlen"}.
@@ -1474,8 +1486,8 @@ add_trans_ci <- function(newdata, object, nsim=100L, alpha=0.05, ...) {
     sim_trans_probs[, i] <- trans_prob
   }
 
-  df$trans_lower <- apply(sim_trans_probs, 1, quantile, probs = alpha / 2, na.rm = TRUE)
-  df$trans_upper <- apply(sim_trans_probs, 1, quantile, probs = 1 - alpha / 2, na.rm = TRUE)
+  df$trans_lower <- apply(sim_trans_probs, 1, quantile, probs = alpha / 2, na.rm = TRUE, type = 6)
+  df$trans_upper <- apply(sim_trans_probs, 1, quantile, probs = 1 - alpha / 2, na.rm = TRUE, type = 6)
 
   df <- df[order(df$.orig_row), , drop = FALSE]
   df$.orig_row <- NULL

--- a/R/cumulative-coefficient.R
+++ b/R/cumulative-coefficient.R
@@ -245,7 +245,7 @@ get_cumu_coef_baseline <- function(
 #'
 #' CIs are calculated by sampling coefficients from their posterior and
 #' calculating the cumulative hazard difference \code{nsim} times. The CI
-#' are obtained by the 2.5\% and 97.5\% quantiles.
+#' are obtained by the 2.5\% and 97.5\% empirical (type-6) quantiles.
 #'
 #' @param d1 A data set used as \code{newdata} in \code{predict.gam}
 #' @param d2 See \code{d1}
@@ -291,8 +291,8 @@ compute_cumu_diff <- function(
       cumsum(intlen1 * exp(drop(X1 %*% z)))
   })
 
-  cumu_lower <- apply(sim_fit_mat, 1, quantile, probs = alpha / 2)
-  cumu_upper <- apply(sim_fit_mat, 1, quantile, probs = 1 - alpha / 2)
+  cumu_lower <- apply(sim_fit_mat, 1, quantile, probs = alpha / 2, type = 6)
+  cumu_upper <- apply(sim_fit_mat, 1, quantile, probs = 1 - alpha / 2, type = 6)
   haz1 <- exp(drop(X1 %*% model$coefficients))
   haz2 <- exp(drop(X2 %*% model$coefficients))
   cumu_diff <- cumsum(haz2 * intlen2) - cumsum(haz1 * intlen1)

--- a/man/add_cif.Rd
+++ b/man/add_cif.Rd
@@ -44,7 +44,8 @@ the data set? Defaults to \code{FALSE}. If \code{TRUE}, columns with names
 
 \item{nsim}{Number of simulations (draws from posterior of estimated coefficients)
 on which estimation of CIFs and their confidence/credible intervals will be
-based on.}
+based on. Interval bounds are empirical type-6 quantiles of the \code{nsim}
+draws; larger values of \code{nsim} yield more stable interval bounds.}
 
 \item{cause_var}{Character. Column name of the 'cause' variable.}
 

--- a/man/add_hazard.Rd
+++ b/man/add_hazard.Rd
@@ -63,7 +63,16 @@ respective intervals. \code{"delta"} calculates CIs based on the standard
 error calculated by the Delta method. \code{"sim"} draws the
 property of interest from its posterior based on the normal distribution of
 the estimated coefficients. See \href{https://adibender.github.io/simpamm/confidence-intervals.html}{here}
-for details and empirical evaluation.}
+for details and empirical evaluation. For \code{ci_type = "sim"}, interval
+bounds are empirical quantiles (type 6, see \code{\link[stats]{quantile}})
+of \code{nsim} posterior draws (default \code{nsim = 100L}, passed via
+\code{...}). Type-6 quantiles avoid the systematic inward bias that the
+\code{\link[stats]{quantile}} default (type 7) exhibits for small
+\code{nsim}, but at the default \code{nsim = 100} the bounds are estimated
+from few tail draws and thus noisy; increase \code{nsim} (e.g., to 500 or
+more) for more stable interval bounds. Very small \code{nsim}
+(\code{nsim < 2 / alpha - 1}, i.e., below 39 for \code{alpha = 0.05})
+cannot achieve the nominal level at all.}
 
 \item{overwrite}{Should hazard columns be overwritten if already present in
 the data set? Defaults to \code{FALSE}. If \code{TRUE}, columns with names

--- a/man/add_trans_prob.Rd
+++ b/man/add_trans_prob.Rd
@@ -38,7 +38,9 @@ intervals for transition probabilities are calculated.}
 \item{alpha}{Sets the confidence intervals' \eqn{\alpha} level, Defaults to \code{0.05}}
 
 \item{nsim}{Sets the number of iterations for simulated confidence intervals.
-Defaults to \code{100L}}
+Defaults to \code{100L}. Interval bounds are empirical type-6 quantiles of
+the \code{nsim} draws; larger values of \code{nsim} yield more stable
+interval bounds.}
 
 \item{time_var}{Name of the variable used for the baseline hazard. Defaults
 to \code{"tend"}.}

--- a/man/compute_cumu_diff.Rd
+++ b/man/compute_cumu_diff.Rd
@@ -25,6 +25,6 @@ returns the design matrix (e.g., \code{mgcv::gam}).}
 \description{
 CIs are calculated by sampling coefficients from their posterior and
 calculating the cumulative hazard difference \code{nsim} times. The CI
-are obtained by the 2.5\\% and 97.5\\% quantiles.
+are obtained by the 2.5\\% and 97.5\\% empirical (type-6) quantiles.
 }
 \keyword{internal}

--- a/man/get_cumu_hazard.Rd
+++ b/man/get_cumu_hazard.Rd
@@ -35,7 +35,16 @@ respective intervals. \code{"delta"} calculates CIs based on the standard
 error calculated by the Delta method. \code{"sim"} draws the
 property of interest from its posterior based on the normal distribution of
 the estimated coefficients. See \href{https://adibender.github.io/simpamm/confidence-intervals.html}{here}
-for details and empirical evaluation.}
+for details and empirical evaluation. For \code{ci_type = "sim"}, interval
+bounds are empirical quantiles (type 6, see \code{\link[stats]{quantile}})
+of \code{nsim} posterior draws (default \code{nsim = 100L}, passed via
+\code{...}). Type-6 quantiles avoid the systematic inward bias that the
+\code{\link[stats]{quantile}} default (type 7) exhibits for small
+\code{nsim}, but at the default \code{nsim = 100} the bounds are estimated
+from few tail draws and thus noisy; increase \code{nsim} (e.g., to 500 or
+more) for more stable interval bounds. Very small \code{nsim}
+(\code{nsim < 2 / alpha - 1}, i.e., below 39 for \code{alpha = 0.05})
+cannot achieve the nominal level at all.}
 
 \item{time_var}{Name of the variable used for the baseline hazard. Defaults
 to \code{"tend"}.}

--- a/man/get_hazard.Rd
+++ b/man/get_hazard.Rd
@@ -47,7 +47,16 @@ respective intervals. \code{"delta"} calculates CIs based on the standard
 error calculated by the Delta method. \code{"sim"} draws the
 property of interest from its posterior based on the normal distribution of
 the estimated coefficients. See \href{https://adibender.github.io/simpamm/confidence-intervals.html}{here}
-for details and empirical evaluation.}
+for details and empirical evaluation. For \code{ci_type = "sim"}, interval
+bounds are empirical quantiles (type 6, see \code{\link[stats]{quantile}})
+of \code{nsim} posterior draws (default \code{nsim = 100L}, passed via
+\code{...}). Type-6 quantiles avoid the systematic inward bias that the
+\code{\link[stats]{quantile}} default (type 7) exhibits for small
+\code{nsim}, but at the default \code{nsim = 100} the bounds are estimated
+from few tail draws and thus noisy; increase \code{nsim} (e.g., to 500 or
+more) for more stable interval bounds. Very small \code{nsim}
+(\code{nsim < 2 / alpha - 1}, i.e., below 39 for \code{alpha = 0.05})
+cannot achieve the nominal level at all.}
 
 \item{time_var}{Name of the variable used for the baseline hazard. Defaults
 to \code{"tend"}.}

--- a/tests/testthat/test-add-functions.R
+++ b/tests/testthat/test-add-functions.R
@@ -133,6 +133,69 @@ test_that("hazard functions work for PAM", {
   ))
 })
 
+test_that("simulation based CIs use type-6 quantiles (#288)", {
+  # nsim = 100 exercises the interpolation branch of the type-6 quantile;
+  # for nsim < 39 the 2.5% bound would degenerate to min/max of the draws
+  nd <- ped_info(ped)
+  set.seed(288)
+  haz_sim <- add_hazard(nd, pam, ci_type = "sim", nsim = 100L)
+  # reproduce the posterior draws (no other RNG is consumed before rmvnorm)
+  # and compare against type-6 quantiles
+  set.seed(288)
+  X <- predict(pam, newdata = nd, type = "lpmatrix")
+  sim_coef_mat <- mvtnorm::rmvnorm(100L, mean = coef(pam), sigma = pam$Vp)
+  sim_fit_mat <- apply(sim_coef_mat, 1, function(z) exp(X %*% z))
+  expect_equal(
+    haz_sim$ci_lower,
+    apply(sim_fit_mat, 1, quantile, probs = 0.025, type = 6),
+    ignore_attr = TRUE
+  )
+  expect_equal(
+    haz_sim$ci_upper,
+    apply(sim_fit_mat, 1, quantile, probs = 0.975, type = 6),
+    ignore_attr = TRUE
+  )
+  # type-6 intervals always contain the type-7 intervals for the same draws
+  expect_true(all(
+    haz_sim$ci_lower <= apply(sim_fit_mat, 1, quantile, probs = 0.025, type = 7)
+  ))
+  expect_true(all(
+    haz_sim$ci_upper >= apply(sim_fit_mat, 1, quantile, probs = 0.975, type = 7)
+  ))
+
+  # same check for the cumulative hazard and survival probability paths
+  set.seed(288)
+  cumu_sim <- add_cumu_hazard(nd, pam, ci_type = "sim", nsim = 100L)
+  set.seed(288)
+  surv_sim <- add_surv_prob(nd, pam, ci_type = "sim", nsim = 100L)
+  sim_cumu_mat <- apply(
+    sim_coef_mat,
+    1,
+    function(z) cumsum(nd$intlen * exp(X %*% z))
+  )
+  sim_surv_mat <- exp(-sim_cumu_mat)
+  expect_equal(
+    cumu_sim$cumu_lower,
+    apply(sim_cumu_mat, 1, quantile, probs = 0.025, type = 6),
+    ignore_attr = TRUE
+  )
+  expect_equal(
+    cumu_sim$cumu_upper,
+    apply(sim_cumu_mat, 1, quantile, probs = 0.975, type = 6),
+    ignore_attr = TRUE
+  )
+  expect_equal(
+    surv_sim$surv_lower,
+    apply(sim_surv_mat, 1, quantile, probs = 0.025, type = 6),
+    ignore_attr = TRUE
+  )
+  expect_equal(
+    surv_sim$surv_upper,
+    apply(sim_surv_mat, 1, quantile, probs = 0.975, type = 6),
+    ignore_attr = TRUE
+  )
+})
+
 test_that("hazard functions work for PEM", {
   expect_data_frame(
     haz <- add_hazard(ped_info(ped), pem),
@@ -197,8 +260,8 @@ test_that("cumulative hazard functions work for PAM", {
   ## sim CI (0.95)
   set.seed(123)
   haz3 <- ped_info(ped) %>% add_cumu_hazard(pam, ci_type = "sim")
-  expect_equal(round(haz3$cumu_upper, 2), c(.06, .11, .19, .25, .34))
-  expect_equal(round(haz3$cumu_lower, 2), c(.02, .04, .08, .13, .17))
+  expect_equal(round(haz3$cumu_upper, 2), c(.06, .11, .19, .26, .35))
+  expect_equal(round(haz3$cumu_lower, 2), c(.02, .04, .08, .12, .16))
 
   ## check that hazard columns are not deleted
   newdata <- ped_info(ped) %>% add_hazard(pam) %>% add_cumu_hazard(pam)
@@ -514,8 +577,8 @@ test_that("survival probabilities functions work for PAM", {
   # sim CI
   set.seed(123)
   surv3 <- add_surv_prob(ped_info(ped), pam, ci_type = "sim")
-  expect_equal(round(surv3$surv_lower, 2), c(.94, .90, .83, .78, .71))
-  expect_equal(round(surv3$surv_upper, 2), c(.98, .96, .92, .88, .84))
+  expect_equal(round(surv3$surv_lower, 2), c(.94, .89, .82, .77, .70))
+  expect_equal(round(surv3$surv_upper, 2), c(.98, .96, .92, .89, .85))
 })
 
 test_that("CIF works with pamm", {


### PR DESCRIPTION
Closes #288.

## Problem

All simulation-based CIs computed interval bounds as empirical `alpha/2` / `1 - alpha/2` quantiles of `nsim` posterior coefficient draws via `stats::quantile()` with its default `type = 7`. For B draws, `E[F(X_(k))] = k/(B+1)`, so type-7 bounds at `B = 100` enclose an expected central mass of only ~93.1% instead of the nominal 95% — the intervals are systematically too narrow even if the posterior approximation were perfect (see #288 for the full derivation and the Monte Carlo evidence from the #285 study).

## Changes

- `quantile(..., type = 6)` (plotting positions `k/(B+1)`, which remove the systematic inward bias) at **all six** sim-CI sites: `get_sim_ci()`, `get_sim_ci_cumu()`, `get_sim_ci_surv()` (i.e. `add_hazard()` / `add_cumu_hazard()` / `add_surv_prob()` with `ci_type = "sim"`), `get_cif.default()` (`add_cif()`), `add_trans_ci()` (`add_trans_prob()` — a site not listed in the issue), and `compute_cumu_diff()` (`get_cumu_coef()`).
- Documentation: the `ci_type`/`nsim` docs now state the type-6 construction, that the default `nsim = 100` gives noisy bounds (recommend 500+), and that `nsim < 2/alpha - 1` (39 for alpha = 0.05) cannot achieve the nominal level at all. NEWS entry notes that all sim-CI bounds widen slightly relative to <= 0.7.5.
- Tests: new seed-reproduction regression test verifying the bounds equal type-6 quantiles of the posterior draws for the hazard, cumulative-hazard, and survival paths (at `nsim = 100`, exercising the interpolation branch); four hardcoded snapshot values updated (all widen, as the math predicts).

Default `nsim` values are deliberately unchanged (100, `add_cif()` already at 500): the type fix removes a *bias*, raising `nsim` reduces *Monte Carlo noise* — an orthogonal, runtime-relevant decision better made separately (issue #288, point 2).

## Validation

Beyond the unit tests, the fix was validated empirically by rerunning part of the #285 Monte Carlo study ([`attic/simulations/ci-surv-prob`](https://github.com/adibender/pammtools/tree/claude/confident-cori-dng5at/attic/simulations/ci-surv-prob) on branch `claude/confident-cori-dng5at`; nominal-95% CIs for S(t|x), not included in this PR — verification artifacts and protocol in [`results-type6/`](https://github.com/adibender/pammtools/tree/claude/confident-cori-dng5at/attic/simulations/ci-surv-prob/results-type6), commit 7e6a41c): scenarios 1, 30, 33 — the three with the worst sim100 coverage in the full 500-rep run — x 100 reps with the patched package. Since the study's RNG streams are deterministic per (scenario, rep), the rerun is exactly paired with reps 1-100 of the stored type-7 results: point estimates and the (unaffected) delta/default bounds agree to <= 1e-4, so only the quantile type differs.

| method | type-7 coverage | type-6 coverage | gain | theory predicts | cells flipping miss→cover / cover→miss | median width ratio |
|---|---|---|---|---|---|---|
| sim, nsim = 100 | 0.907 | 0.928 | +2.1pp | ~+1.9pp | 59 / 2 | 1.081 |
| sim, nsim = 500 | 0.919 | 0.925 | +0.6pp | ~+0.4pp | 16 / 1 | 1.016 |

Gains match the order-statistics prediction within Monte Carlo error, and coverage flips are essentially one-directional (type-6 intervals contain the type-7 intervals for the same draws). Residual under-coverage in these worst-case cells (heavy censoring, late times) is the late-hazard fit bias documented in the #285 study — it affects delta and sim CIs alike and is out of scope here.

`R CMD check`: 0 errors, 0 warnings, 4 pre-existing notes (untouched files). Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
